### PR TITLE
Mapped diagnostic context logging

### DIFF
--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/activity/message/consumer/bean/ActivityMessageConsumerBean.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/activity/message/consumer/bean/ActivityMessageConsumerBean.java
@@ -35,6 +35,8 @@ import javax.inject.Inject;
 import javax.jms.Message;
 import javax.jms.MessageListener;
 import javax.jms.TextMessage;
+
+import eu.europa.ec.fisheries.uvms.commons.message.context.MappedDiagnosticContext;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,6 +87,7 @@ public class ActivityMessageConsumerBean implements MessageListener {
         TextMessage textMessage = null;
         try {
             textMessage = (TextMessage) message;
+            MappedDiagnosticContext.addMessagePropertiesToThreadMappedDiagnosticContext(textMessage);
             ActivityModuleRequest request;
             request = JAXBMarshaller.unmarshallTextMessage(textMessage, ActivityModuleRequest.class);
             LOG.debug("Message unmarshalled successfully in activity");

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <hibernate.version>4.3.11.Final</hibernate.version>
         <hibernate-spatial.version>4.3</hibernate-spatial.version>
         <geotools.version>14.4</geotools.version>
-        <uvms.commons.version>3.0.12</uvms.commons.version>
+        <uvms.commons.version>3.0.16-SNAPSHOT</uvms.commons.version>
         <uvms.test.version>0.0.4</uvms.test.version>
         <hibernate.validator.version>4.3.2.Final</hibernate.validator.version>
         <hibernate-entitymanager.version>4.3.11.Final</hibernate-entitymanager.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <hibernate.version>4.3.11.Final</hibernate.version>
         <hibernate-spatial.version>4.3</hibernate-spatial.version>
         <geotools.version>14.4</geotools.version>
-        <uvms.commons.version>3.0.17-SNAPSHOT</uvms.commons.version>
+        <uvms.commons.version>3.0.17</uvms.commons.version>
         <uvms.test.version>0.0.4</uvms.test.version>
         <hibernate.validator.version>4.3.2.Final</hibernate.validator.version>
         <hibernate-entitymanager.version>4.3.11.Final</hibernate-entitymanager.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <hibernate.version>4.3.11.Final</hibernate.version>
         <hibernate-spatial.version>4.3</hibernate-spatial.version>
         <geotools.version>14.4</geotools.version>
-        <uvms.commons.version>3.0.16</uvms.commons.version>
+        <uvms.commons.version>3.0.17-SNAPSHOT</uvms.commons.version>
         <uvms.test.version>0.0.4</uvms.test.version>
         <hibernate.validator.version>4.3.2.Final</hibernate.validator.version>
         <hibernate-entitymanager.version>4.3.11.Final</hibernate-entitymanager.version>

--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -20,7 +20,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{0}.%M\(%line\)) %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %highlight(%-5level) %cyan(%logger{0}.%M\(%line\)) %X{userId}- %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -37,7 +37,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{0}.%M\(%line\)) %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %highlight(%-5level) %cyan(%logger{0}.%M\(%line\)) %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
@@ -46,7 +46,7 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>

--- a/service/src/test/java/eu/europa/ec/fisheries/ers/mapper/subscription/ActivityToSubscriptionMapperTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/ers/mapper/subscription/ActivityToSubscriptionMapperTest.java
@@ -56,7 +56,7 @@ public class ActivityToSubscriptionMapperTest {
         DateTimeType startDateTime = new DateTimeType();
 
         GregorianCalendar cal = new GregorianCalendar();
-        DateTime dateTime = DateUtils.XML_FORMATTER.parseDateTime("2016-07-01T02:00:00.000+02:00");
+        DateTime dateTime = DateUtils.XML_FORMATTER.parseDateTime("2016-07-01T02:00:00Z");
         cal.setTime(dateTime.toDate());
         XMLGregorianCalendar xmlDate = DatatypeFactory.newInstance().newXMLGregorianCalendar(cal);
         startDateTime.setDateTime(xmlDate);
@@ -65,7 +65,7 @@ public class ActivityToSubscriptionMapperTest {
         DateTimeType endDateTime = new DateTimeType();
 
         GregorianCalendar cal2 = new GregorianCalendar();
-        DateTime dateTime2 = DateUtils.XML_FORMATTER.parseDateTime("2017-07-01T02:00:00.000+02:00");
+        DateTime dateTime2 = DateUtils.XML_FORMATTER.parseDateTime("2017-07-01T02:00:00Z");
         cal2.setTime(dateTime2.toDate());
         XMLGregorianCalendar xmlDate2 = DatatypeFactory.newInstance().newXMLGregorianCalendar(cal2);
         endDateTime.setDateTime(xmlDate2);

--- a/service/src/test/java/eu/europa/ec/fisheries/ers/mapper/subscription/ActivityToSubscriptionMapperTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/ers/mapper/subscription/ActivityToSubscriptionMapperTest.java
@@ -28,7 +28,6 @@ import eu.europa.ec.fisheries.wsdl.subscription.module.ValueType;
 import lombok.SneakyThrows;
 import org.joda.time.DateTime;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import un.unece.uncefact.data.standard.fluxfaquerymessage._3.FLUXFAQueryMessage;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.DelimitedPeriod;
@@ -39,7 +38,6 @@ import un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.DateTimeType;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.IDType;
 
-@Ignore
 public class ActivityToSubscriptionMapperTest {
 
     private FLUXFAQueryMessage fluxfaQueryMessage = new FLUXFAQueryMessage();

--- a/service/src/test/java/eu/europa/ec/fisheries/ers/service/bean/ActivityMessageConsumerBeanTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/ers/service/bean/ActivityMessageConsumerBeanTest.java
@@ -10,10 +10,12 @@ details. You should have received a copy of the GNU General Public License along
 */
 package eu.europa.ec.fisheries.ers.service.bean;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 import javax.enterprise.event.Event;
+import javax.jms.TextMessage;
 
 import eu.europa.ec.fisheries.schema.exchange.module.v1.ExchangeModuleMethod;
 import eu.europa.ec.fisheries.schema.exchange.module.v1.ReceiveSalesReportRequest;
@@ -22,22 +24,30 @@ import eu.europa.ec.fisheries.uvms.activity.message.event.carrier.EventMessage;
 import eu.europa.ec.fisheries.uvms.activity.model.mapper.JAXBMarshaller;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.ActivityModuleMethod;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.GetNonUniqueIdsRequest;
+import eu.europa.ec.fisheries.uvms.commons.message.context.MappedDiagnosticContext;
 import lombok.SneakyThrows;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.mockito.internal.util.reflection.Whitebox;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Created by kovian on 17/07/2017.
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({MappedDiagnosticContext.class})
+@PowerMockIgnore( {"javax.management.*"})
 public class ActivityMessageConsumerBeanTest {
 
     @InjectMocks
@@ -67,34 +77,50 @@ public class ActivityMessageConsumerBeanTest {
     @Mock
     Event<EventMessage> errorEvent;
 
+    @Before
+    public void initMocks() {
+        MockitoAnnotations.initMocks(this);
+    }
 
     @Test
     @SneakyThrows
     public void testOnMessageMethod(){
+        mockStatic(MappedDiagnosticContext.class);
+        PowerMockito.doNothing().when(MappedDiagnosticContext.class, "addMessagePropertiesToThreadMappedDiagnosticContext", Mockito.any(TextMessage.class));
         for(ActivityModuleMethod moduleMethod : ActivityModuleMethod.values()){
+
             GetNonUniqueIdsRequest request = new GetNonUniqueIdsRequest();
             request.setMethod(moduleMethod);
             ActiveMQTextMessage textMessage = new ActiveMQTextMessage(session);
             final String strReq = JAXBMarshaller.marshallJaxBObjectToString(request);
             Whitebox.setInternalState(textMessage, "text", new SimpleString(strReq));
+
             consumer.onMessage(textMessage);
+
+            PowerMockito.verifyStatic();
+            MappedDiagnosticContext.addMessagePropertiesToThreadMappedDiagnosticContext(textMessage);
         }
-        verify(receiveFishingActivityEvent,times(2)).fire(Mockito.any(EventMessage.class));
-        verify(getFishingTripListEvent,times(1)).fire(Mockito.any(EventMessage.class));
-        verify(getFACatchSummaryReportEvent,times(1)).fire(Mockito.any(EventMessage.class));
-        verify(getNonUniqueIdsRequest,times(1)).fire(Mockito.any(EventMessage.class));
+        verify(mapToSubscriptionRequest, times(1)).fire(any(EventMessage.class));
+        verify(receiveFishingActivityEvent,times(2)).fire(any(EventMessage.class));
+        verify(getFishingTripListEvent,times(1)).fire(any(EventMessage.class));
+        verify(getFACatchSummaryReportEvent,times(1)).fire(any(EventMessage.class));
+        verify(getNonUniqueIdsRequest,times(1)).fire(any(EventMessage.class));
     }
 
     @Test
     @SneakyThrows
     public void testThrowing(){
+        mockStatic(MappedDiagnosticContext.class);
+        PowerMockito.doNothing().when(MappedDiagnosticContext.class, "addMessagePropertiesToThreadMappedDiagnosticContext", Mockito.any(TextMessage.class));
         ReceiveSalesReportRequest request = new ReceiveSalesReportRequest();
         request.setMethod(ExchangeModuleMethod.RECEIVE_SALES_REPORT);
         ActiveMQTextMessage textMessage = new ActiveMQTextMessage(session);
         final String strReq = JAXBMarshaller.marshallJaxBObjectToString(request);
         Whitebox.setInternalState(textMessage, "text", new SimpleString(strReq));
         consumer.onMessage(textMessage);
-        verify(errorEvent,times(1)).fire(Mockito.any(EventMessage.class));
+        PowerMockito.verifyStatic();
+        MappedDiagnosticContext.addMessagePropertiesToThreadMappedDiagnosticContext(textMessage);
+        verify(errorEvent,times(1)).fire(any(EventMessage.class));
     }
 
 }


### PR DESCRIPTION
The Union commons message library has been extended with Mapped diagnostic context functionality.
The Mapped diagnostic context data (MDC) could be attached to the processing thread of an initiating request message flow.
The JMS message properties will be used to help the MDC data travel between Union modules.
The MDC  parameter: requestId has been added as a logging pattern in the logback logging configuration.
This enables us to have a message flow trace available in Union for log aggregation purposes.