### PR TITLE
Remove color code from file logs, and add them to console logs

### DIFF
--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -20,7 +20,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %highlight(%-5level) %cyan(%logger{0}.%M\(%line\)) %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{0}.%M\(%line\) %X{userId}- %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -37,7 +37,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %highlight(%-5level) %cyan(%logger{0}.%M\(%line\)) %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{0}.%M\(%line\) %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
@@ -46,7 +46,7 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %highlight(%-5level) %cyan(%logger{40}) %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>


### PR DESCRIPTION
In the past, colors were added to the logs, which helps readability in the console.
When you open the file logs, you'll see "weird characters": 

_2018-07-02 15:59:24  **[1;31m**ERROR**[0;39m [36m**jndiUtil.createJNDI(32)**[0;39m** - Could not bind value to key USM/secretKey_

These characters obfuscate the logs, and make it harder for tools like Logstash to interpret them.

I've removed the color codes from the file logger, but kept them in the console logger.