### PR TITLE
Log format: log milliseconds

### DIFF
--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -20,7 +20,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{0}.%M\(%line\) %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %X{requestId} %-5level %logger{0}.%M\(%line\) %X{userId}- %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -37,7 +37,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{0}.%M\(%line\) %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %X{requestId} %-5level %logger{0}.%M\(%line\) %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
@@ -46,7 +46,7 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %highlight(%-5level) %cyan(%logger{40}) %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %X{requestId} %highlight(%-5level) %cyan(%logger{40}) %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>

--- a/service/src/test/resources/logback.xml
+++ b/service/src/test/resources/logback.xml
@@ -20,7 +20,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -28,7 +28,7 @@
     <!-- CONSOLE DEBUGGER -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>


### PR DESCRIPTION
When using log aggregators, like Elastic Search, the logs are not ordered correctly, because the log timestamps are too vague. We would like the log timestamp to include milliseconds.