### PR TITLE
Add Fa Report Document to Vessel Transport Means

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/bean/FluxMessageServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/bean/FluxMessageServiceBean.java
@@ -201,6 +201,7 @@ public class FluxMessageServiceBean extends BaseActivityBean implements FluxMess
         if(CollectionUtils.isNotEmpty(faReportDocument.getVesselTransportMeans())) {
             for(VesselTransportMeansEntity vesselTransportMeansEntity : faReportDocument.getVesselTransportMeans()) {
                 enrichWithGuidFromAssets(vesselTransportMeansEntity);
+                vesselTransportMeansEntity.setFaReportDocument(faReportDocument);
             }
         }
         Set<FishingActivityEntity> fishingActivities=faReportDocument.getFishingActivities();


### PR DESCRIPTION
When receiving and saving an Activity report, in the activity_vessel_transport_means table, the fa_report_document_id isn't filled in. 
By adding this, it's possible to join faReportDocument from vesselTransportMeans.