### PR TITLE
Ers 240 unmapped policy error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <audit.model.version>4.0.10</audit.model.version>
 
         <!-- Third-party dependency versions -->
-        <mapstruct.version>1.2.0.Final</mapstruct.version>
+        <mapstruct.version>1.3.1.Final</mapstruct.version>
         <jackson.version>2.10.0</jackson.version>
         <geotools.version>14.4</geotools.version>
         <xmlunit.version>1.6</xmlunit.version>

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/AapProcessCodeMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/AapProcessCodeMapper.java
@@ -18,7 +18,7 @@ import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface AapProcessCodeMapper {
 
     AapProcessCodeMapper INSTANCE = Mappers.getMapper(AapProcessCodeMapper.class);
@@ -26,10 +26,22 @@ public interface AapProcessCodeMapper {
     @Mappings({
             @Mapping(target = "value", source = "typeCode"),
             @Mapping(target = "listID", source = "typeCodeListId"),
+            @Mapping(target = "listAgencyID", ignore = true),
+            @Mapping(target = "listAgencyName", ignore = true),
+            @Mapping(target = "listName", ignore = true),
+            @Mapping(target = "listVersionID", ignore = true),
+            @Mapping(target = "name", ignore = true),
+            @Mapping(target = "languageID", ignore = true),
+            @Mapping(target = "listURI", ignore = true),
+            @Mapping(target = "listSchemeURI", ignore = true),
     })
     CodeType mapToCodeType(AapProcessCodeEntity aapProcessCodeEntity);
 
     @InheritInverseConfiguration
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "aapProcess", ignore = true)
+    })
     AapProcessCodeEntity mapToAapProcessCodeEntity(CodeType codeType);
 
     Set<AapProcessCodeEntity> mapToAapProcessCodeEntitySet(List<CodeType> codeType);

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/AapProcessMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/AapProcessMapper.java
@@ -17,7 +17,7 @@ import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.AAPProcess;
 
 @Mapper(uses = {AapProcessCodeMapper.class, AapProductMapper.class},
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface AapProcessMapper {
 
     AapProcessMapper INSTANCE = Mappers.getMapper(AapProcessMapper.class);
@@ -26,6 +26,8 @@ public interface AapProcessMapper {
             @Mapping(target = "conversionFactor", source = "conversionFactorNumeric.value"),
             @Mapping(target = "aapProcessCode", ignore = true),
             @Mapping(target = "aapProducts", ignore = true),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "faCatch", ignore = true)
     })
     AapProcessEntity mapToAapProcessEntity(AAPProcess aapProcess);
 
@@ -33,6 +35,7 @@ public interface AapProcessMapper {
     @Mappings({
             @Mapping(source = "aapProducts", target = "resultAAPProducts"),
             @Mapping(source = "aapProcessCode", target = "typeCodes"),
+            @Mapping(target = "usedFACatches", ignore = true)
     })
     AAPProcess mapToAapProcess(AapProcessEntity aapProcess);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/AapProductMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/AapProductMapper.java
@@ -24,7 +24,7 @@ import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.AAPProduct;
 
 @Mapper(uses = CustomBigDecimal.class,
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class AapProductMapper {
 
     public static final AapProductMapper INSTANCE = Mappers.getMapper(AapProductMapper.class);
@@ -52,9 +52,22 @@ public abstract class AapProductMapper {
             @Mapping(target = "weighingMeansCodeListId", source = "weighingMeansCode.listID"),
             @Mapping(target = "usageCode", source = "usageCode.value"),
             @Mapping(target = "usageCodeListId", source = "usageCode.listID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "calculatedPackagingWeight", ignore = true),
+            @Mapping(target = "calculatedPackagingUnitCount", ignore = true),
+            @Mapping(target = "calculatedUnitQuantity", ignore = true),
+            @Mapping(target = "calculatedWeightMeasure", ignore = true),
+            @Mapping(target = "aapProcess", ignore = true)
     })
     public abstract AapProductEntity mapToAapProductEntity(AAPProduct aapProduct);
 
+    @Mappings({
+            @Mapping(target = "totalSalesPrice", ignore = true),
+            @Mapping(target = "specifiedSizeDistribution", ignore = true),
+            @Mapping(target = "originFishingActivity", ignore = true),
+            @Mapping(target = "appliedAAPProcesses", ignore = true),
+            @Mapping(target = "originFLUXLocations", ignore = true)
+    })
     @InheritInverseConfiguration
     public abstract AAPProduct mapToAapProduct(AapProductEntity aapProductEntity);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/AapStockMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/AapStockMapper.java
@@ -19,7 +19,7 @@ import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.AAPStock;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface AapStockMapper {
 
     AapStockMapper INSTANCE = Mappers.getMapper(AapStockMapper.class);
@@ -27,6 +27,8 @@ public interface AapStockMapper {
     @Mappings({
             @Mapping(target = "stockId", source = "ID.value"),
             @Mapping(target = "stockSchemeId", source = "ID.schemeID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "faCatch", ignore = true),
     })
     AapStockEntity mapToAapStockEntity(AAPStock aapStock);
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/ContactPartyMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/ContactPartyMapper.java
@@ -35,7 +35,7 @@ import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentit
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType;
 
 @Mapper(uses = {ContactPersonMapper.class, StructuredAddressMapper.class},
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class ContactPartyMapper extends BaseMapper {
 
     public static final ContactPartyMapper INSTANCE = Mappers.getMapper(ContactPartyMapper.class);
@@ -50,7 +50,9 @@ public abstract class ContactPartyMapper extends BaseMapper {
 
     @Mappings({
             @Mapping(target = "roleCode", source = "value"),
-            @Mapping(target = "roleCodeListId", source = "listID")
+            @Mapping(target = "roleCodeListId", source = "listID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "contactParty", ignore = true),
     })
     public abstract ContactPartyRoleEntity mapToContactPartyRoleEntity(CodeType codeType);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/ContactPersonMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/ContactPersonMapper.java
@@ -20,7 +20,7 @@ import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.ContactPerson;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface ContactPersonMapper {
 
     ContactPersonMapper INSTANCE = Mappers.getMapper(ContactPersonMapper.class);
@@ -33,15 +33,29 @@ public interface ContactPersonMapper {
             @Mapping(target = "familyNamePrefix", source = "familyNamePrefix.value"),
             @Mapping(target = "nameSuffix", source = "nameSuffix.value"),
             @Mapping(target = "gender", source = "genderCode.value"),
-            @Mapping(target = "alias", source = "alias.value")
+            @Mapping(target = "alias", source = "alias.value"),
             // TODO map gender
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "contactParty", ignore = true),
     })
     ContactPersonEntity mapToContactPersonEntity(ContactPerson contactPerson);
 
     @InheritInverseConfiguration
+    @Mappings({
+            @Mapping(target = "birthDateTime", ignore = true),
+            @Mapping(target = "birthplaceName", ignore = true),
+            @Mapping(target = "telephoneTelecommunicationCommunication", ignore = true),
+            @Mapping(target = "faxTelecommunicationCommunication", ignore = true),
+            @Mapping(target = "emailURIEmailCommunication", ignore = true),
+            @Mapping(target = "websiteURIWebsiteCommunication", ignore = true),
+            @Mapping(target = "specifiedUniversalCommunications", ignore = true)
+    })
     ContactPerson mapToContactPerson(ContactPersonEntity contactPerson);
 
     List<ContactPerson> mapToContactPersonList(Set<ContactPersonEntity> contactPerson);
 
+    @Mappings({
+            @Mapping(target = "characteristicsMap", ignore = true)
+    })
     ContactPersonDetailsDTO mapToContactPersonDetailsDTO(ContactPersonEntity contactPersonEntity);
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/DelimitedPeriodMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/DelimitedPeriodMapper.java
@@ -23,7 +23,7 @@ import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.DelimitedPeriod;
 
 @Mapper(uses = {XMLDateUtils.class, CustomBigDecimal.class},
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface DelimitedPeriodMapper {
 
     DelimitedPeriodMapper INSTANCE = Mappers.getMapper(DelimitedPeriodMapper.class);
@@ -31,7 +31,11 @@ public interface DelimitedPeriodMapper {
     @Mappings({
             @Mapping(target = "startDate", source = "startDateTime.dateTime"),
             @Mapping(target = "endDate", source = "endDateTime.dateTime"),
-            @Mapping(target = "durationMeasure", source = "durationMeasure")
+            @Mapping(target = "durationMeasure", source = "durationMeasure"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "fishingActivity", ignore = true),
+            @Mapping(target = "fishingTrip", ignore = true),
+            @Mapping(target = "calculatedDuration", ignore = true)
     })
     DelimitedPeriodEntity mapToDelimitedPeriodEntity(DelimitedPeriod delimitedPeriod);
 
@@ -40,6 +44,10 @@ public interface DelimitedPeriodMapper {
 
     List<DelimitedPeriod> mapToDelimitedPeriodList(Set<DelimitedPeriodEntity> delimitedPeriod);
 
+    @Mappings({
+            @Mapping(target = "duration", ignore = true),
+            @Mapping(target = "unitCode", ignore = true)
+    })
     DelimitedPeriodDTO mapToDelimitedPeriodDTO(DelimitedPeriodEntity delimitedPeriodEntity);
 
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FAReportIdentifierMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FAReportIdentifierMapper.java
@@ -16,18 +16,30 @@ import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.IDType;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface FAReportIdentifierMapper {
 
     FAReportIdentifierMapper INSTANCE = Mappers.getMapper(FAReportIdentifierMapper.class);
 
     @Mappings({
             @Mapping(target = "faReportIdentifierId", source = "value"),
-            @Mapping(target = "faReportIdentifierSchemeId", source = "schemeID")
+            @Mapping(target = "faReportIdentifierSchemeId", source = "schemeID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "faReportDocument", ignore = true),
     })
     FaReportIdentifierEntity mapToFluxReportIdentifierEntity(IDType idType);
 
     @InheritInverseConfiguration
+    @Mappings({
+            @Mapping(target = "value", ignore = true),
+            @Mapping(target = "schemeID", ignore = true),
+            @Mapping(target = "schemeName", ignore = true),
+            @Mapping(target = "schemeAgencyID", ignore = true),
+            @Mapping(target = "schemeAgencyName", ignore = true),
+            @Mapping(target = "schemeVersionID", ignore = true),
+            @Mapping(target = "schemeDataURI", ignore = true),
+            @Mapping(target = "schemeURI", ignore = true),
+    })
     IDType mapToFluxReportIdentifier(FluxReportIdentifierEntity idType);
 
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FaCatchMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FaCatchMapper.java
@@ -41,7 +41,7 @@ import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.*;
 
 @Mapper(uses = {CustomBigDecimal.class, SizeDistributionMapper.class, FishingGearMapper.class, FluxCharacteristicsMapper.class, FishingTripMapper.class, AapProcessMapper.class, AapStockMapper.class, FluxCharacteristicsViewDtoMapper.class, VesselIdentifierMapper.class},
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class FaCatchMapper extends BaseMapper {
 
     public static final FaCatchMapper INSTANCE = Mappers.getMapper(FaCatchMapper.class);
@@ -66,7 +66,20 @@ public abstract class FaCatchMapper extends BaseMapper {
             @Mapping(target = "fluxLocations", expression = "java(getFluxLocationEntities(faCatch.getSpecifiedFLUXLocations(), faCatch.getDestinationFLUXLocations(), faCatchEntity))"),
             @Mapping(target = "fluxCharacteristics", expression = "java(getFluxCharacteristicEntities(faCatch.getApplicableFLUXCharacteristics(), faCatchEntity))"),
             @Mapping(target = "aapStocks", expression = "java(getAapStockEntities(faCatch.getRelatedAAPStocks(), faCatchEntity))"),
-            @Mapping(target = "fishingTrips", expression = "java(BaseMapper.mapToFishingTripEntitySet(faCatch.getRelatedFishingTrips(), faCatchEntity))")
+            @Mapping(target = "fishingTrips", expression = "java(BaseMapper.mapToFishingTripEntitySet(faCatch.getRelatedFishingTrips(), faCatchEntity))"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "fishingActivity", ignore = true),
+            @Mapping(target = "calculatedUnitQuantity", ignore = true),
+            @Mapping(target = "calculatedWeightMeasure", ignore = true),
+            @Mapping(target = "territory", ignore = true),
+            @Mapping(target = "faoArea", ignore = true),
+            @Mapping(target = "icesStatRectangle", ignore = true),
+            @Mapping(target = "effortZone", ignore = true),
+            @Mapping(target = "rfmo", ignore = true),
+            @Mapping(target = "gfcmGsa", ignore = true),
+            @Mapping(target = "gfcmStatRectangle", ignore = true),
+            @Mapping(target = "presentation", ignore = true),
+            @Mapping(target = "gearTypeCode", ignore = true)
     })
     public abstract FaCatchEntity mapToFaCatchEntity(FACatch faCatch);
 
@@ -74,10 +87,28 @@ public abstract class FaCatchMapper extends BaseMapper {
     @Mappings({
             @Mapping(target = "appliedAAPProcesses", source = "aapProcesses"),
             @Mapping(target = "specifiedSizeDistribution", source = "sizeDistribution"),
-            @Mapping(target = "specifiedSizeDistribution.classCodes", source = "sizeDistribution.sizeDistributionClassCodeEntities")
+            @Mapping(target = "specifiedSizeDistribution.classCodes", source = "sizeDistribution.sizeDistributionClassCodeEntities"),
+            @Mapping(target = "relatedFishingTrips", ignore = true),
+            @Mapping(target = "relatedAAPStocks", ignore = true),
+            @Mapping(target = "relatedSalesBatches", ignore = true),
+            @Mapping(target = "specifiedFLUXLocations", ignore = true),
+            @Mapping(target = "usedFishingGears", ignore = true),
+            @Mapping(target = "applicableFLUXCharacteristics", ignore = true),
+            @Mapping(target = "destinationFLUXLocations", ignore = true)
     })
     public abstract FACatch mapToFaCatch(FaCatchEntity faCatch);
 
+    @Mappings({
+            @Mapping(target = "listID", ignore = true),
+            @Mapping(target = "listAgencyID", ignore = true),
+            @Mapping(target = "listAgencyName", ignore = true),
+            @Mapping(target = "listName", ignore = true),
+            @Mapping(target = "listVersionID", ignore = true),
+            @Mapping(target = "name", ignore = true),
+            @Mapping(target = "languageID", ignore = true),
+            @Mapping(target = "listURI", ignore = true),
+            @Mapping(target = "listSchemeURI", ignore = true)
+    })
     public abstract un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType map(java.lang.String value);
 
     @Mappings({

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FaReportDocumentMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FaReportDocumentMapper.java
@@ -48,7 +48,7 @@ import un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.IDType;
 
 @Mapper(uses = {FAReportIdentifierMapper.class},
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class FaReportDocumentMapper extends BaseMapper {
 
     public static final FaReportDocumentMapper INSTANCE = Mappers.getMapper(FaReportDocumentMapper.class);
@@ -62,7 +62,12 @@ public abstract class FaReportDocumentMapper extends BaseMapper {
             @Mapping(target = "status", constant = "NEW"),
             @Mapping(target = "source", source = "faReportSourceEnum.sourceType"),
             @Mapping(target = "fluxReportDocument", expression = "java(getFluxReportDocument(faReportDocument.getRelatedFLUXReportDocument(), faReportDocumentEntity))"),
-            @Mapping(target = "faReportIdentifiers", source = "faReportDocument.relatedReportIDs")
+            @Mapping(target = "faReportIdentifiers", source = "faReportDocument.relatedReportIDs"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "geom", ignore = true),
+            @Mapping(target = "fluxFaReportMessage", ignore = true),
+            @Mapping(target = "fishingActivities", ignore = true),
+            @Mapping(target = "vesselTransportMeans", ignore = true),
     })
     public abstract FaReportDocumentEntity mapToFAReportDocumentEntity(FAReportDocument faReportDocument, FaReportSourceEnum faReportSourceEnum);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FishingActivityIdentifierMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FishingActivityIdentifierMapper.java
@@ -19,7 +19,7 @@ import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.IDType;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface FishingActivityIdentifierMapper {
 
     FishingActivityIdentifierMapper INSTANCE = Mappers.getMapper(FishingActivityIdentifierMapper.class);
@@ -30,11 +30,21 @@ public interface FishingActivityIdentifierMapper {
 
     @Mappings({
             @Mapping(target = "faIdentifierId", source = "value"),
-            @Mapping(target = "faIdentifierSchemeId", source = "schemeID")
+            @Mapping(target = "faIdentifierSchemeId", source = "schemeID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "fishingActivity", ignore = true)
     })
     FishingActivityIdentifierEntity mapToFishingActivityIdentifierEntity(IDType idType);
 
     @InheritInverseConfiguration
+    @Mappings({
+            @Mapping(target = "schemeName", ignore = true),
+            @Mapping(target = "schemeAgencyID", ignore = true),
+            @Mapping(target = "schemeAgencyName", ignore = true),
+            @Mapping(target = "schemeVersionID", ignore = true),
+            @Mapping(target = "schemeDataURI", ignore = true),
+            @Mapping(target = "schemeURI", ignore = true)
+    })
     IDType mapToIDType(FishingActivityIdentifierEntity identifierEntity);
 
     List<IDType> mapToIDTypeList(Set<FishingActivityIdentifierEntity> identifierEntities);

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FishingGearMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FishingGearMapper.java
@@ -23,7 +23,7 @@ import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentit
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType;
 
 @Mapper(uses = {GearCharacteristicsMapper.class},
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface FishingGearMapper {
 
     FishingGearMapper INSTANCE = Mappers.getMapper(FishingGearMapper.class);
@@ -33,6 +33,10 @@ public interface FishingGearMapper {
             @Mapping(target = "typeCodeListId", source = "typeCode.listID"),
             @Mapping(target = "fishingGearRole", ignore = true),
             @Mapping(target = "gearCharacteristics", ignore = true),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "faCatch", ignore = true),
+            @Mapping(target = "fishingActivity", ignore = true),
+            @Mapping(target = "gearProblem", ignore = true)
     })
     FishingGearEntity mapToFishingGearEntity(FishingGear fishingGear);
 
@@ -40,6 +44,7 @@ public interface FishingGearMapper {
     @Mappings({
             @Mapping(target = "roleCodes", source = "fishingGearRole"),
             @Mapping(target = "applicableGearCharacteristics", source = "gearCharacteristics"),
+            @Mapping(target = "illustrateFLUXPictures", ignore = true)
     })
     FishingGear mapToFishingGear(FishingGearEntity fishingGearEntity);
 
@@ -47,16 +52,29 @@ public interface FishingGearMapper {
 
     @Mappings({
             @Mapping(source = "typeCode",target = "gearTypeCode"),
+            @Mapping(target = "gearRoleCode", ignore = true)
     })
     FishingGearDTO mapToFishingGearDTO(FishingGearEntity fishingGearEntity);
 
     @Mappings({
             @Mapping(target = "roleCode", source = "value"),
-            @Mapping(target = "roleCodeListId", source = "listID")
+            @Mapping(target = "roleCodeListId", source = "listID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "fishingGear", ignore = true)
     })
     FishingGearRoleEntity mapToFishingGearRoleEntity(CodeType codeType);
 
     @InheritInverseConfiguration
+    @Mappings({
+            @Mapping(target = "listAgencyID", ignore = true),
+            @Mapping(target = "listAgencyName", ignore = true),
+            @Mapping(target = "listName", ignore = true),
+            @Mapping(target = "listVersionID", ignore = true),
+            @Mapping(target = "name", ignore = true),
+            @Mapping(target = "languageID", ignore = true),
+            @Mapping(target = "listURI", ignore = true),
+            @Mapping(target = "listSchemeURI", ignore = true)
+    })
     CodeType mapToFishingGearRole(FishingGearRoleEntity codeType);
 
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FishingTripIdentifierMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FishingTripIdentifierMapper.java
@@ -15,18 +15,30 @@ import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.IDType;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface FishingTripIdentifierMapper {
 
     FishingTripIdentifierMapper INSTANCE = Mappers.getMapper(FishingTripIdentifierMapper.class);
 
     @Mappings({
             @Mapping(target = "tripId", source = "value"),
-            @Mapping(target = "tripSchemeId", source = "schemeID")
+            @Mapping(target = "tripSchemeId", source = "schemeID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "calculatedTripStartDate", ignore = true),
+            @Mapping(target = "calculatedTripEndDate", ignore = true),
+            @Mapping(target = "fishingTrip", ignore = true)
     })
     FishingTripIdentifierEntity mapToFishingTripIdentifier(IDType idType);
 
     @InheritInverseConfiguration
+    @Mappings({
+            @Mapping(target = "schemeName", ignore = true),
+            @Mapping(target = "schemeAgencyID", ignore = true),
+            @Mapping(target = "schemeAgencyName", ignore = true),
+            @Mapping(target = "schemeVersionID", ignore = true),
+            @Mapping(target = "schemeDataURI", ignore = true),
+            @Mapping(target = "schemeURI", ignore = true),
+    })
     IDType mapToIDType(FishingTripIdentifierEntity idType);
 
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FishingTripMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FishingTripMapper.java
@@ -20,7 +20,7 @@ import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FishingTrip;
 
 @Mapper(uses = {FishingTripIdentifierMapper.class, DelimitedPeriodMapper.class},
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface FishingTripMapper {
 
     FishingTripMapper INSTANCE = Mappers.getMapper(FishingTripMapper.class);
@@ -30,6 +30,9 @@ public interface FishingTripMapper {
             @Mapping(target = "typeCodeListId", source = "typeCode.listID"),
             @Mapping(target = "delimitedPeriods", ignore = true),
             @Mapping(target = "fishingTripIdentifiers", ignore = true),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "faCatch", ignore = true),
+            @Mapping(target = "fishingActivity", ignore = true),
     })
     FishingTripEntity mapToFishingTripEntity(FishingTrip fishingTrip);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FlapDocumentMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FlapDocumentMapper.java
@@ -23,7 +23,7 @@ import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FLAPDocument;
 
 @Mapper(uses = BaseMapper.class,
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface FlapDocumentMapper {
 
     FlapDocumentMapper INSTANCE = Mappers.getMapper(FlapDocumentMapper.class);
@@ -32,10 +32,34 @@ public interface FlapDocumentMapper {
             @Mapping(target = "flapDocumentId", source = "ID.value"),
             @Mapping(target = "flapDocumentSchemeId", source = "ID.schemeID"),
             @Mapping(target = "flapTypeCode", source = "typeCode.value"),
-            @Mapping(target = "flapTypeCodeListId", source = "typeCode.listID")
+            @Mapping(target = "flapTypeCodeListId", source = "typeCode.listID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "fishingActivity", ignore = true),
+            @Mapping(target = "vesselTransportMeans", ignore = true),
+            @Mapping(target = "fluxCharacteristic", ignore = true)
     })
     FlapDocumentEntity mapToFlapDocumentEntity(FLAPDocument flapDocument);
 
+    @Mappings({
+            @Mapping(target = "name", ignore = true),
+            @Mapping(target = "firstApplicationIndicator", ignore = true),
+            @Mapping(target = "remarks", ignore = true),
+            @Mapping(target = "decisionDateTime", ignore = true),
+            @Mapping(target = "entryIntoForceDelimitedPeriod", ignore = true),
+            @Mapping(target = "vesselIDs", ignore = true),
+            @Mapping(target = "joinedVesselIDs", ignore = true),
+            @Mapping(target = "specifiedFLUXCharacteristics", ignore = true),
+            @Mapping(target = "specifiedVesselCrews", ignore = true),
+            @Mapping(target = "applicableDelimitedPeriods", ignore = true),
+            @Mapping(target = "specifiedVesselTransportCharters", ignore = true),
+            @Mapping(target = "specifiedContactParties", ignore = true),
+            @Mapping(target = "specifiedTargetedQuotas", ignore = true),
+            @Mapping(target = "attachedFLUXBinaryFiles", ignore = true),
+            @Mapping(target = "specifiedFLUXLocations", ignore = true),
+            @Mapping(target = "relatedValidationResultDocuments", ignore = true),
+            @Mapping(target = "relatedFLAPRequestDocuments", ignore = true),
+            @Mapping(target = "specifiedAuthorizationStatuses", ignore = true)
+    })
     @InheritInverseConfiguration
     FLAPDocument mapToFlapDocument(FlapDocumentEntity flapDocument);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FluxCharacteristicsMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FluxCharacteristicsMapper.java
@@ -18,7 +18,7 @@ import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FLUXCharacteristic;
 
-@Mapper(imports = BaseMapper.class, uses = CustomBigDecimal.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(imports = BaseMapper.class, uses = CustomBigDecimal.class, unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface FluxCharacteristicsMapper {
 
     FluxCharacteristicsMapper INSTANCE = Mappers.getMapper(FluxCharacteristicsMapper.class);
@@ -38,11 +38,23 @@ public interface FluxCharacteristicsMapper {
             @Mapping(target = "description", expression = "java(BaseMapper.getTextFromList(fluxCharacteristic.getDescriptions()))"),
             @Mapping(target = "descriptionLanguageId", expression = "java(BaseMapper.getLanguageIdFromList(fluxCharacteristic.getDescriptions()))"),
             @Mapping(target = "fluxLocation", ignore = true),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "calculatedValueMeasure", ignore = true),
+            @Mapping(target = "calculatedValueQuantity", ignore = true),
+            @Mapping(target = "faCatch", ignore = true),
+            @Mapping(target = "fishingActivity", ignore = true),
+            @Mapping(target = "flapDocument", ignore = true)
 
     })
     FluxCharacteristicEntity mapToFluxCharEntity(FLUXCharacteristic fluxCharacteristic);
 
     @InheritInverseConfiguration
+    @Mappings({
+            @Mapping(target = "descriptions", ignore = true),
+            @Mapping(target = "values", ignore = true),
+            @Mapping(target = "specifiedFLUXLocations", ignore = true),
+            @Mapping(target = "relatedFLAPDocuments", ignore = true)
+    })
     FLUXCharacteristic mapToFLUXCharacteristic(FluxCharacteristicEntity fluxCharacteristicEntity);
 
     FluxCharacteristicsDto mapToFluxCharacteristicsDto(FluxCharacteristicEntity fluxCharacteristicEntity);

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FluxPartyMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FluxPartyMapper.java
@@ -36,7 +36,7 @@ import un.unece.uncefact.data.standard.unqualifieddatatype._20.IDType;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.TextType;
 
 @Mapper(imports = BaseMapper.class,
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class FluxPartyMapper {
 
     public static final FluxPartyMapper INSTANCE = Mappers.getMapper(FluxPartyMapper.class);
@@ -45,12 +45,16 @@ public abstract class FluxPartyMapper {
             @Mapping(target = "fluxPartyName", expression = "java(BaseMapper.getTextFromList(fluxParty.getNames()))"),
             @Mapping(target = "nameLanguageId", expression = "java(BaseMapper.getLanguageIdFromList(fluxParty.getNames()))"),
             @Mapping(target = "fluxPartyIdentifiers", expression = "java(mapToFluxPartyIdentifierEntities(fluxParty.getIDS(), fluxPartyEntity))"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "fluxReportDocument", ignore = true)
     })
     public abstract FluxPartyEntity mapToFluxPartyEntity(FLUXParty fluxParty);
 
     @Mappings({
             @Mapping(target = "fluxPartyIdentifierId", source = "value"),
-            @Mapping(target = "fluxPartyIdentifierSchemeId", source = "schemeID")
+            @Mapping(target = "fluxPartyIdentifierSchemeId", source = "schemeID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "fluxParty", ignore = true)
     })
     public abstract FluxPartyIdentifierEntity mapToFluxPartyIdentifierEntity(IDType idType);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FluxReportDocumentMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FluxReportDocumentMapper.java
@@ -19,7 +19,7 @@ import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentit
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType;
 
 @Mapper(uses = {XMLDateUtils.class, FluxReportIdentifierMapper.class, FluxPartyMapper.class, CodeTypeMapper.class},
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface FluxReportDocumentMapper {
 
     FluxReportDocumentMapper INSTANCE = Mappers.getMapper(FluxReportDocumentMapper.class);
@@ -33,12 +33,26 @@ public interface FluxReportDocumentMapper {
             @Mapping(target = "purpose", source = "purpose.value"),
             @Mapping(target = "fluxReportIdentifiers", source = "IDS"),
             @Mapping(target = "fluxParty", source = "ownerFLUXParty"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "fluxFaReportMessage", ignore = true),
+            @Mapping(target = "faReportDocument", ignore = true)
     })
     FluxReportDocumentEntity mapToFluxReportDocumentEntity(FLUXReportDocument fluxReportDocument);
 
     @InheritInverseConfiguration
     FLUXReportDocument mapToFluxReportDocument(FluxReportDocumentEntity fluxReportDocument);
 
+    @Mappings({
+            @Mapping(target = "listID", ignore = true),
+            @Mapping(target = "listAgencyID", ignore = true),
+            @Mapping(target = "listAgencyName", ignore = true),
+            @Mapping(target = "listName", ignore = true),
+            @Mapping(target = "listVersionID", ignore = true),
+            @Mapping(target = "name", ignore = true),
+            @Mapping(target = "languageID", ignore = true),
+            @Mapping(target = "listURI", ignore = true),
+            @Mapping(target = "listSchemeURI", ignore = true)
+    })
     CodeType map(java.lang.String value);
 
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FluxReportIdentifierMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/FluxReportIdentifierMapper.java
@@ -16,17 +16,28 @@ import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.IDType;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface FluxReportIdentifierMapper {
 
     FluxReportIdentifierMapper INSTANCE = Mappers.getMapper(FluxReportIdentifierMapper.class);
 
     @Mappings({
             @Mapping(target = "fluxReportIdentifierId", source = "value"),
-            @Mapping(target = "fluxReportIdentifierSchemeId", source = "schemeID")
+            @Mapping(target = "fluxReportIdentifierSchemeId", source = "schemeID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "fluxReportDocument", ignore = true)
     })
     FluxReportIdentifierEntity mapToFluxReportIdentifierEntity(IDType idType);
 
+
+    @Mappings({
+            @Mapping(target = "schemeName", ignore = true),
+            @Mapping(target = "schemeAgencyID", ignore = true),
+            @Mapping(target = "schemeAgencyName", ignore = true),
+            @Mapping(target = "schemeVersionID", ignore = true),
+            @Mapping(target = "schemeDataURI", ignore = true),
+            @Mapping(target = "schemeURI", ignore = true),
+    })
     @InheritInverseConfiguration
     IDType mapToFluxReportIdentifier(FluxReportIdentifierEntity idType);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/GearCharacteristicsMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/GearCharacteristicsMapper.java
@@ -42,7 +42,7 @@ import static eu.europa.ec.fisheries.ers.service.mapper.view.base.ViewConstants.
 
 @Mapper(imports = BaseMapper.class,
         uses = CustomBigDecimal.class,
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class GearCharacteristicsMapper {
 
     public static final GearCharacteristicsMapper INSTANCE = Mappers.getMapper(GearCharacteristicsMapper.class);
@@ -60,10 +60,18 @@ public abstract class GearCharacteristicsMapper {
             @Mapping(target = "valueText", source = "value.value"),
             @Mapping(target = "valueQuantity", source = "valueQuantity.value"),
             @Mapping(target = "valueQuantityCode", source = "valueQuantity.unitCode"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "calculatedValueMeasure", ignore = true),
+            @Mapping(target = "calculatedValueQuantity", ignore = true),
+            @Mapping(target = "fishingGear", ignore = true)
     })
     public abstract GearCharacteristicEntity mapToGearCharacteristicEntity(GearCharacteristic gearCharacteristic);
 
     @InheritInverseConfiguration
+    @Mappings({
+            @Mapping(target = "descriptions", ignore = true),
+            @Mapping(target = "specifiedFLUXLocations", ignore = true),
+    })
     public abstract GearCharacteristic mapToGearCharacteristic(GearCharacteristicEntity gearCharacteristic);
 
     public GearDto mapGearDtoToFishingGearEntity(FishingGearEntity fishingGearEntity) {

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/GearProblemMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/GearProblemMapper.java
@@ -33,7 +33,7 @@ import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentit
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType;
 
 @Mapper(uses = {FishingGearMapper.class, FluxLocationMapper.class},
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class GearProblemMapper extends BaseMapper {
 
     public static final GearProblemMapper INSTANCE = Mappers.getMapper(GearProblemMapper.class);
@@ -44,13 +44,17 @@ public abstract class GearProblemMapper extends BaseMapper {
             @Mapping(target = "affectedQuantity", source = "affectedQuantity.value"),
             @Mapping(target = "gearProblemRecovery", expression = "java(mapToGearProblemRecoveries(gearProblem.getRecoveryMeasureCodes(), gearProblemEntity))"),
             @Mapping(target = "fishingGears", expression = "java(getFishingGearsEntities(gearProblem.getRelatedFishingGears(), gearProblemEntity))"),
-            @Mapping(target = "locations", expression = "java(mapToFluxLocations(gearProblem.getSpecifiedFLUXLocations(), gearProblemEntity))")
+            @Mapping(target = "locations", expression = "java(mapToFluxLocations(gearProblem.getSpecifiedFLUXLocations(), gearProblemEntity))"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "fishingActivity", ignore = true),
     })
     public abstract GearProblemEntity mapToGearProblemEntity(GearProblem gearProblem);
 
     @Mappings({
             @Mapping(target = "recoveryMeasureCode", source = "value"),
-            @Mapping(target = "recoveryMeasureCodeListId", source = "listID")
+            @Mapping(target = "recoveryMeasureCodeListId", source = "listID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "gearProblem", ignore = true),
     })
     public abstract GearProblemRecoveryEntity mapToGearProblemRecoveryEntity(CodeType codeType);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/RegistrationEventMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/RegistrationEventMapper.java
@@ -20,7 +20,7 @@ import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.RegistrationEvent;
 
 @Mapper(imports = BaseMapper.class,
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface RegistrationEventMapper {
 
     RegistrationEventMapper INSTANCE = Mappers.getMapper(RegistrationEventMapper.class);
@@ -30,6 +30,8 @@ public interface RegistrationEventMapper {
             @Mapping(target = "descLanguageId", expression = "java(BaseMapper.getLanguageIdFromList(registrationEvent.getDescriptions()))"),
             @Mapping(target = "occurrenceDatetime", source = "occurrenceDateTime.dateTime"),
             @Mapping(target = "registrationLocation", expression = "java(BaseMapper.mapToRegistrationLocationEntity(registrationEvent.getRelatedRegistrationLocation(), registrationEventEntity))"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "vesselTransportMeanses", ignore = true),
     })
     RegistrationEventEntity mapToRegistrationEventEntity(RegistrationEvent registrationEvent);
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/RegistrationLocationMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/RegistrationLocationMapper.java
@@ -20,7 +20,7 @@ import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.RegistrationLocation;
 
 @Mapper(imports = BaseMapper.class,
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface RegistrationLocationMapper {
 
     RegistrationLocationMapper INSTANCE = Mappers.getMapper(RegistrationLocationMapper.class);
@@ -36,6 +36,8 @@ public interface RegistrationLocationMapper {
             @Mapping(target = "typeCodeListId", source = "typeCode.listID"),
             @Mapping(target = "locationCountryId", source = "countryID.value"),
             @Mapping(target = "locationCountrySchemeId", source = "countryID.schemeID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "registrationEvent", ignore = true),
     })
     RegistrationLocationEntity mapToRegistrationLocationEntity(RegistrationLocation registrationLocation);
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/SizeDistributionMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/SizeDistributionMapper.java
@@ -19,27 +19,45 @@ import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentit
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType;
 
 @Mapper(imports = BaseMapper.class,
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface SizeDistributionMapper {
 
     SizeDistributionMapper INSTANCE = Mappers.getMapper(SizeDistributionMapper.class);
 
     @Mappings({
             @Mapping(target = "categoryCode", source = "categoryCode.value"),
-            @Mapping(target = "categoryCodeListId", source = "categoryCode.listID")
+            @Mapping(target = "categoryCodeListId", source = "categoryCode.listID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "faCatch", ignore = true),
+            @Mapping(target = "sizeDistributionClassCodeEntities", ignore = true)
     })
     SizeDistributionEntity mapToSizeDistributionEntity(SizeDistribution sizeDistribution);
 
     @InheritInverseConfiguration
+    @Mappings({
+            @Mapping(target = "classCodes", ignore = true)
+    })
     SizeDistribution mapToSizeDistribution(SizeDistributionEntity sizeDistributionEntity);
 
     @Mappings({
             @Mapping(target = "classCode", source = "value"),
-            @Mapping(target = "classCodeListId", source = "listID")
+            @Mapping(target = "classCodeListId", source = "listID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "sizeDistribution", ignore = true),
     })
     SizeDistributionClassCodeEntity mapToSizeDistributionClassCodeEntity(CodeType codeType);
 
     @InheritInverseConfiguration
+    @Mappings({
+            @Mapping(target = "listAgencyID", ignore = true),
+            @Mapping(target = "listAgencyName", ignore = true),
+            @Mapping(target = "listName", ignore = true),
+            @Mapping(target = "listVersionID", ignore = true),
+            @Mapping(target = "name", ignore = true),
+            @Mapping(target = "languageID", ignore = true),
+            @Mapping(target = "listURI", ignore = true),
+            @Mapping(target = "listSchemeURI", ignore = true)
+    })
     CodeType mapToSizeDistributionClassCode(SizeDistributionClassCodeEntity classCodeEntity);
 
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/StructuredAddressMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/StructuredAddressMapper.java
@@ -20,7 +20,7 @@ import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.StructuredAddress;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface StructuredAddressMapper {
 
     StructuredAddressMapper INSTANCE = Mappers.getMapper(StructuredAddressMapper.class);
@@ -46,7 +46,11 @@ public interface StructuredAddressMapper {
             @Mapping(target = "streetName", source = "streetName.value"),
             @Mapping(target = "staircaseNumberValue", source = "staircaseNumber.value"),
             @Mapping(target = "floorIdentificationValue", source = "floorIdentification.value"),
-            @Mapping(target = "roomIdentificationValue", source = "roomIdentification.value")
+            @Mapping(target = "roomIdentificationValue", source = "roomIdentification.value"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "structuredAddressType", ignore = true),
+            @Mapping(target = "contactParty", ignore = true),
+            @Mapping(target = "fluxLocation", ignore = true)
     })
     StructuredAddressEntity mapToStructuredAddressEntity(StructuredAddress structuredAddress);
 
@@ -57,6 +61,9 @@ public interface StructuredAddressMapper {
 
     Set<StructuredAddressEntity> mapToStructuredAddressEntitySet(List<StructuredAddress> structuredAddress);
 
+    @Mappings({
+            @Mapping(target = "characteristicsMap", ignore = true)
+    })
     AddressDetailsDTO mapToAddressDetailsDTO(StructuredAddressEntity structuredAddressEntity);
 
     Set<AddressDetailsDTO> mapToAddressDetailsDTOList(Set<StructuredAddressEntity> structuredAddressEntities);

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/StructuredAddressMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/StructuredAddressMapper.java
@@ -61,9 +61,6 @@ public interface StructuredAddressMapper {
 
     Set<StructuredAddressEntity> mapToStructuredAddressEntitySet(List<StructuredAddress> structuredAddress);
 
-    @Mappings({
-            @Mapping(target = "characteristicsMap", ignore = true)
-    })
     AddressDetailsDTO mapToAddressDetailsDTO(StructuredAddressEntity structuredAddressEntity);
 
     Set<AddressDetailsDTO> mapToAddressDetailsDTOList(Set<StructuredAddressEntity> structuredAddressEntities);

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/VesselIdentifierMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/VesselIdentifierMapper.java
@@ -20,14 +20,16 @@ import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(uses = BaseMapper.class,
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface VesselIdentifierMapper {
 
     VesselIdentifierMapper INSTANCE = Mappers.getMapper(VesselIdentifierMapper.class);
 
     @Mappings({
             @Mapping(target = "identifierSchemeId", source = "vesselIdentifierSchemeId"),
-            @Mapping(target = "faIdentifierId", source = "vesselIdentifierId")
+            @Mapping(target = "faIdentifierId", source = "vesselIdentifierId"),
+            @Mapping(target = "faIdentifierSchemeId", ignore = true),
+            @Mapping(target = "fromAssets", ignore = true),
     })
     AssetIdentifierDto mapToIdentifierDto(VesselIdentifierEntity entity);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/VesselPositionEventMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/VesselPositionEventMapper.java
@@ -22,7 +22,7 @@ import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.VesselPositionEvent;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface VesselPositionEventMapper {
 
     VesselPositionEventMapper INSTANCE = Mappers.getMapper(VesselPositionEventMapper.class);
@@ -36,7 +36,8 @@ public interface VesselPositionEventMapper {
             @Mapping(target = "altitude", source = "vesselPositionEvent.specifiedVesselGeographicalCoordinate.altitudeMeasure.value"),
             @Mapping(target = "longitude", source = "vesselPositionEvent.specifiedVesselGeographicalCoordinate.longitudeMeasure.value"),
             @Mapping(target = "activityTypeCode", source = "vesselPositionEvent.activityTypeCode.value"),
-            @Mapping(target = "vesselTransportMeans", source = "vesselTransportMeansEntity")
+            @Mapping(target = "vesselTransportMeans", source = "vesselTransportMeansEntity"),
+            @Mapping(target = "geom", ignore = true),
     })
     VesselPositionEventEntity mapToVesselPositionEventEntity(VesselPositionEvent vesselPositionEvent,VesselTransportMeansEntity vesselTransportMeansEntity);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/VesselStorageCharacteristicsMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/VesselStorageCharacteristicsMapper.java
@@ -28,7 +28,7 @@ import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentit
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType;
 
 @Mapper(uses = {VesselStorageCharCodeMapper.class},
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class VesselStorageCharacteristicsMapper {
 
     public static final VesselStorageCharacteristicsMapper INSTANCE = Mappers.getMapper(VesselStorageCharacteristicsMapper.class);
@@ -37,12 +37,17 @@ public abstract class VesselStorageCharacteristicsMapper {
             @Mapping(target = "vesselId", source = "vesselStorageCharacteristic.ID.value"),
             @Mapping(target = "vesselSchemaId", source = "vesselStorageCharacteristic.ID.schemeID"),
             @Mapping(target = "vesselStorageCharCode", expression = "java(mapToVesselStorageCharCodes(vesselStorageCharacteristic.getTypeCodes(), vesselStorageCharacteristicsEntity))"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "fishingActivitiesForDestVesselCharId", ignore = true),
+            @Mapping(target = "fishingActivitiesForSourceVesselCharId", ignore = true)
     })
     public abstract VesselStorageCharacteristicsEntity mapToDestVesselStorageCharEntity(VesselStorageCharacteristic vesselStorageCharacteristic);
 
     @Mappings({
             @Mapping(target = "vesselTypeCode", source = "value"),
-            @Mapping(target = "vesselTypeCodeListId", source = "listID")
+            @Mapping(target = "vesselTypeCodeListId", source = "listID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "vesselStorageCharacteristics", ignore = true)
     })
     protected abstract VesselStorageCharCodeEntity mapToVesselStorageCharCodeEntity(CodeType codeType);
 
@@ -63,6 +68,7 @@ public abstract class VesselStorageCharacteristicsMapper {
             @Mapping(target = "identifier.faIdentifierId", source = "vesselId"),
             @Mapping(target = "identifier.faIdentifierSchemeId", source = "vesselSchemaId"),
             @Mapping(target = "vesselStorageCharCodeDto", source = "firstVesselStorageCharCode"),
+            @Mapping(target = "identifiers", ignore = true),
     })
     public abstract StorageDto mapToStorageDto(VesselStorageCharacteristicsEntity entity);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/VesselTransportMeansMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/VesselTransportMeansMapper.java
@@ -29,7 +29,7 @@ import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentit
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.IDType;
 
 @Mapper(uses = {FaReportDocumentMapper.class, VesselIdentifierMapper.class, ContactPartyMapper.class, FlapDocumentMapper.class,VesselStorageCharacteristicsMapper.class},
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class VesselTransportMeansMapper extends BaseMapper {
 
     public static final VesselTransportMeansMapper INSTANCE = Mappers.getMapper(VesselTransportMeansMapper.class);
@@ -43,19 +43,28 @@ public abstract class VesselTransportMeansMapper extends BaseMapper {
             @Mapping(target = "vesselIdentifiers", expression = "java(mapToVesselIdentifierEntities(vesselTransportMeans.getIDS(), vesselTransportMeansEntity))"),
             @Mapping(target = "contactParty", expression = "java(getContactPartyEntity(vesselTransportMeans.getSpecifiedContactParties(), vesselTransportMeansEntity))"),
             @Mapping(target = "registrationEvent", expression = "java(getRegistrationEventEntity(vesselTransportMeans.getSpecifiedRegistrationEvents(), vesselTransportMeansEntity))"),
-            @Mapping(target = "vesselPositionEvents", expression = "java(getVesselPositionEventEntities(vesselTransportMeans.getSpecifiedVesselPositionEvents(),vesselTransportMeansEntity))")
+            @Mapping(target = "vesselPositionEvents", expression = "java(getVesselPositionEventEntities(vesselTransportMeans.getSpecifiedVesselPositionEvents(),vesselTransportMeansEntity))"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "guid", ignore = true),
+            @Mapping(target = "fishingActivity", ignore = true),
+            @Mapping(target = "faReportDocument", ignore = true),
+            @Mapping(target = "flapDocuments", ignore = true),
+            @Mapping(target = "vesselIdentifiersMap", ignore = true)
     })
     public abstract VesselTransportMeansEntity mapToVesselTransportMeansEntity(VesselTransportMeans vesselTransportMeans);
 
 
     @Mappings({
             @Mapping(target = "vesselIdentifierId", source = "value"),
-            @Mapping(target = "vesselIdentifierSchemeId", source = "schemeID")
+            @Mapping(target = "vesselIdentifierSchemeId", source = "schemeID"),
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "vesselTransportMeans", ignore = true)
     })
     protected abstract VesselIdentifierEntity mapToVesselIdentifierEntity(IDType idType);
 
     @Mappings({
-           @Mapping(target = "contactPartyDetailsDTOSet", source = "contactParty")
+           @Mapping(target = "contactPartyDetailsDTOSet", source = "contactParty"),
+            @Mapping(target = "storageDto", ignore = true)
     })
     public abstract VesselDetailsDTO map(VesselTransportMeansEntity entity);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/ActivityAreaEntryViewMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/ActivityAreaEntryViewMapper.java
@@ -21,7 +21,7 @@ import org.mapstruct.Mappings;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class ActivityAreaEntryViewMapper extends BaseActivityViewMapper {
 
     public static final ActivityAreaEntryViewMapper INSTANCE = Mappers.getMapper(ActivityAreaEntryViewMapper.class);
@@ -34,7 +34,13 @@ public abstract class ActivityAreaEntryViewMapper extends BaseActivityViewMapper
             @Mapping(target = "catches", expression = "java(mapCatchesToGroupDto(faEntity))"),
             @Mapping(target = "processingProducts", expression = "java(getProcessingProductsByFaCatches(faEntity.getFaCatchs()))"),
             @Mapping(target = "areas", expression = "java(getSortedAreas(faEntity, new eu.europa.ec.fisheries.ers.service.mapper.view.base.FluxLocationDTOSchemeIdComparator()))"),
-            @Mapping(target = "gearProblems", ignore = true)
+            @Mapping(target = "gears", ignore = true),
+            @Mapping(target = "gearProblems", ignore = true),
+            @Mapping(target = "gearShotRetrievalList", ignore = true),
+            @Mapping(target = "tripDetails", ignore = true),
+            @Mapping(target = "vesselDetails", ignore = true),
+            @Mapping(target = "relocations", ignore = true),
+            @Mapping(target = "history", ignore = true),
     })
     public abstract FishingActivityViewDTO mapFaEntityToFaDto(FishingActivityEntity faEntity);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/ActivityAreaExitViewMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/ActivityAreaExitViewMapper.java
@@ -21,7 +21,7 @@ import org.mapstruct.Mappings;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class ActivityAreaExitViewMapper extends BaseActivityViewMapper {
 
     public static final ActivityAreaExitViewMapper INSTANCE = Mappers.getMapper(ActivityAreaExitViewMapper.class);
@@ -34,7 +34,13 @@ public abstract class ActivityAreaExitViewMapper extends BaseActivityViewMapper 
             @Mapping(target = "catches", expression = "java(mapCatchesToGroupDto(faEntity))"),
             @Mapping(target = "processingProducts", expression = "java(getProcessingProductsByFaCatches(faEntity.getFaCatchs()))"),
             @Mapping(target = "areas", expression = "java(getSortedAreas(faEntity, new eu.europa.ec.fisheries.ers.service.mapper.view.base.FluxLocationDTOSchemeIdComparator()))"),
-            @Mapping(target = "gearProblems", ignore = true)
+            @Mapping(target = "gearProblems", ignore = true),
+            @Mapping(target = "gears", ignore = true),
+            @Mapping(target = "gearShotRetrievalList", ignore = true),
+            @Mapping(target = "tripDetails", ignore = true),
+            @Mapping(target = "vesselDetails", ignore = true),
+            @Mapping(target = "relocations", ignore = true),
+            @Mapping(target = "history", ignore = true)
     })
     public abstract FishingActivityViewDTO mapFaEntityToFaDto(FishingActivityEntity faEntity);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/ActivityArrivalViewMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/ActivityArrivalViewMapper.java
@@ -32,7 +32,7 @@ import org.mapstruct.factory.Mappers;
  * Created by kovian on 09/02/2017.
  */
 @Mapper(imports = FluxLocationCatchTypeEnum.class,
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class ActivityArrivalViewMapper extends BaseActivityViewMapper {
 
     public static final ActivityArrivalViewMapper INSTANCE = Mappers.getMapper(ActivityArrivalViewMapper.class);
@@ -44,7 +44,14 @@ public abstract class ActivityArrivalViewMapper extends BaseActivityViewMapper {
             @Mapping(target = "gears", expression = "java(getGearsFromEntity(faEntity.getFishingGears()))"),
             @Mapping(target = "reportDetails", expression = "java(getReportDocsFromEntity(faEntity.getFaReportDocument()))"),
             @Mapping(target = "processingProducts", expression = "java(getProcessingProductsByFaCatches(faEntity.getFaCatchs()))"),
-            @Mapping(target = "gearProblems", ignore = true)
+            @Mapping(target = "gearProblems", ignore = true),
+            @Mapping(target = "catches", ignore = true),
+            @Mapping(target = "gearShotRetrievalList", ignore = true),
+            @Mapping(target = "areas", ignore = true),
+            @Mapping(target = "tripDetails", ignore = true),
+            @Mapping(target = "vesselDetails", ignore = true),
+            @Mapping(target = "relocations", ignore = true),
+            @Mapping(target = "history", ignore = true),
     })
     public abstract FishingActivityViewDTO mapFaEntityToFaDto(FishingActivityEntity faEntity);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/ActivityDepartureViewMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/ActivityDepartureViewMapper.java
@@ -28,7 +28,7 @@ import org.mapstruct.factory.Mappers;
  * Created by padhyad on 3/7/2017.
  */
 @Mapper(imports = FluxLocationCatchTypeEnum.class,
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class ActivityDepartureViewMapper extends BaseActivityViewMapper {
 
     public static final ActivityDepartureViewMapper INSTANCE = Mappers.getMapper(ActivityDepartureViewMapper.class);
@@ -41,7 +41,13 @@ public abstract class ActivityDepartureViewMapper extends BaseActivityViewMapper
             @Mapping(target = "reportDetails", expression = "java(getReportDocsFromEntity(faEntity.getFaReportDocument()))"),
             @Mapping(target = "catches", expression = "java(mapCatchesToGroupDto(faEntity))"),
             @Mapping(target = "processingProducts", expression = "java(getProcessingProductsByFaCatches(faEntity.getFaCatchs()))"),
-            @Mapping(target = "gearProblems", ignore = true)
+            @Mapping(target = "gearProblems", ignore = true),
+            @Mapping(target = "gearShotRetrievalList", ignore = true),
+            @Mapping(target = "areas", ignore = true),
+            @Mapping(target = "tripDetails", ignore = true),
+            @Mapping(target = "vesselDetails", ignore = true),
+            @Mapping(target = "relocations", ignore = true),
+            @Mapping(target = "history", ignore = true)
     })
     public abstract FishingActivityViewDTO mapFaEntityToFaDto(FishingActivityEntity faEntity);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/ActivityLandingViewMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/ActivityLandingViewMapper.java
@@ -32,7 +32,7 @@ import org.mapstruct.factory.Mappers;
  * Created by kovian on 14/02/2017.
  */
 @Mapper(imports = FluxLocationCatchTypeEnum.class,
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class ActivityLandingViewMapper extends BaseActivityViewMapper {
 
     public static final ActivityLandingViewMapper INSTANCE = Mappers.getMapper(ActivityLandingViewMapper.class);
@@ -44,7 +44,14 @@ public abstract class ActivityLandingViewMapper extends BaseActivityViewMapper {
             @Mapping(target = "reportDetails", expression = "java(getReportDocsFromEntity(faEntity.getFaReportDocument()))"),
             @Mapping(target = "catches", expression = "java(mapCatchesToGroupDto(faEntity))"),
             @Mapping(target = "processingProducts", expression = "java(getProcessingProductsByFaCatches(faEntity.getFaCatchs()))"),
-            @Mapping(target = "gearProblems", ignore = true)
+            @Mapping(target = "gears", ignore = true),
+            @Mapping(target = "gearProblems", ignore = true),
+            @Mapping(target = "gearShotRetrievalList", ignore = true),
+            @Mapping(target = "areas", ignore = true),
+            @Mapping(target = "tripDetails", ignore = true),
+            @Mapping(target = "vesselDetails", ignore = true),
+            @Mapping(target = "relocations", ignore = true),
+            @Mapping(target = "history", ignore = true)
     })
     public abstract FishingActivityViewDTO mapFaEntityToFaDto(FishingActivityEntity faEntity);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/ActivityTranshipmentViewMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/ActivityTranshipmentViewMapper.java
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-@Mapper(uses = {VesselTransportMeansMapper.class}, imports = FluxLocationCatchTypeEnum.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(uses = {VesselTransportMeansMapper.class}, imports = FluxLocationCatchTypeEnum.class, unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class ActivityTranshipmentViewMapper extends BaseActivityViewMapper {
 
     public static final ActivityTranshipmentViewMapper INSTANCE = Mappers.getMapper(ActivityTranshipmentViewMapper.class);
@@ -55,7 +55,13 @@ public abstract class ActivityTranshipmentViewMapper extends BaseActivityViewMap
             @Mapping(target = "catches", expression = "java(mapCatchesToGroupDto(faEntity))"),
             @Mapping(target = "processingProducts", expression = "java(getProcessingProductsByFaCatches(faEntity.getFaCatchs()))"),
             @Mapping(target = "vesselDetails", expression = "java(getVesselDetailsDTO(faEntity))"),
-            @Mapping(target = "gearProblems", ignore = true)
+            @Mapping(target = "gearProblems", ignore = true),
+            @Mapping(target = "gears", ignore = true),
+            @Mapping(target = "gearShotRetrievalList", ignore = true),
+            @Mapping(target = "areas", ignore = true),
+            @Mapping(target = "tripDetails", ignore = true),
+            @Mapping(target = "relocations", ignore = true),
+            @Mapping(target = "history", ignore = true)
     })
     public abstract FishingActivityViewDTO mapFaEntityToFaDto(FishingActivityEntity faEntity);
 


### PR DESCRIPTION
Previously we set the MapStruct unmappedTargetPolicy to IGNORE for all mappers, in order to get rid of the large number of warnings that you got when you built the module. This can be dangerous, and in this branch we change the policy to ERROR instead, and explicitly set all unmapped properties to "ignore" (for all mappers except FluxLocationMapper which proved troublesome, will do later).