### PR TITLE
Removed the catch summary REST endpoint.

### DIFF
--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/activity/rest/resources/FACatchResource.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/activity/rest/resources/FACatchResource.java
@@ -12,12 +12,10 @@ details. You should have received a copy of the GNU General Public License along
 package eu.europa.ec.fisheries.uvms.activity.rest.resources;
 
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.ActivityFeaturesEnum;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.FACatchSummaryReportResponse;
 import eu.europa.ec.fisheries.uvms.activity.rest.ActivityExceptionInterceptor;
 import eu.europa.ec.fisheries.uvms.activity.rest.IUserRoleInterceptor;
 import eu.europa.ec.fisheries.uvms.activity.service.FaCatchReportService;
 import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.FACatchDetailsDTO;
-import eu.europa.ec.fisheries.uvms.activity.service.search.FishingActivityQuery;
 import eu.europa.ec.fisheries.uvms.commons.rest.resource.UnionVMSResource;
 import eu.europa.ec.fisheries.uvms.commons.service.exception.ServiceException;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +27,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -48,26 +45,6 @@ public class FACatchResource extends UnionVMSResource {
 
     @EJB
     private FaCatchReportService reportService;
-
-    @POST
-    @Path("/summary")
-    @Consumes(value = {MediaType.APPLICATION_JSON})
-    @Produces(MediaType.APPLICATION_JSON)
-    @Interceptors(ActivityExceptionInterceptor.class)
-    @IUserRoleInterceptor(requiredUserRole = {ActivityFeaturesEnum.LIST_ACTIVITY_REPORTS})
-    public Response getFACatchSummaryReport(@Context HttpServletRequest request,
-                                            @HeaderParam("scopeName") String scopeName,
-                                            @HeaderParam("roleName") String roleName,
-                                            FishingActivityQuery fishingActivityQuery) throws ServiceException {
-
-        log.debug("Query Received to getFACatchSummaryReport. " + fishingActivityQuery);
-        if (fishingActivityQuery == null) {
-            return createErrorResponse("Query to find list is null.");
-        }
-        FACatchSummaryReportResponse faCatchSummaryReportResponse = reportService.getFACatchSummaryReportResponse(fishingActivityQuery);
-        log.debug("Successfully processed");
-        return createSuccessResponse(faCatchSummaryReportResponse);
-    }
 
     @GET
     @Path("/details/{fishingTripId}")

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/activity/rest/resources/FACatchResourceTest.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/activity/rest/resources/FACatchResourceTest.java
@@ -5,37 +5,25 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.FACatchSummaryRecord;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.FACatchSummaryReportResponse;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.FishSizeClassEnum;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.GroupCriteria;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.GroupCriteriaWithValue;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.SummaryFishSize;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.SummaryTable;
 import eu.europa.ec.fisheries.uvms.activity.rest.BaseActivityArquillianTest;
 import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.FACatchDetailsDTO;
 import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.FACatchSummaryDTO;
 import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.SummaryTableDTO;
-import eu.europa.ec.fisheries.uvms.activity.service.search.FishingActivityQuery;
 import eu.europa.ec.fisheries.uvms.commons.rest.dto.ResponseDto;
 import eu.europa.ec.fisheries.uvms.commons.service.exception.ServiceException;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.naming.NamingException;
 import javax.transaction.NotSupportedException;
 import javax.transaction.SystemException;
-import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.xml.bind.JAXBException;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -48,146 +36,6 @@ public class FACatchResourceTest extends BaseActivityArquillianTest {
     @Before
     public void setUp() throws NamingException, IOException, JAXBException, ServiceException, NotSupportedException, SystemException {
         super.setUp();
-    }
-
-    @Test
-    public void getFACatchSummaryReport_byYear() throws JsonProcessingException {
-        // Given
-        FishingActivityQuery query = new FishingActivityQuery();
-
-        query.setSearchCriteriaMap(new HashMap<>());
-        query.setSearchCriteriaMapMultipleValues(new HashMap<>());
-
-        List<GroupCriteria> groupByFields = new ArrayList<>();
-        groupByFields.add(GroupCriteria.DATE_YEAR);
-        query.setGroupByFields(groupByFields);
-
-        // When
-        String responseAsString = getWebTarget()
-                .path("catch")
-                .path("summary")
-                .request(MediaType.APPLICATION_JSON)
-                .header(HttpHeaders.AUTHORIZATION, authToken)
-                .post(Entity.json(query), String.class);
-
-        // Then
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(TypeFactory.defaultInstance()));
-
-        ResponseDto<FACatchSummaryReportResponse> responseDto =
-                objectMapper.readValue(responseAsString, new TypeReference<ResponseDto<FACatchSummaryReportResponse>>(){});
-
-        assertEquals(200, responseDto.getCode());
-        assertNull(responseDto.getMsg());
-
-        FACatchSummaryReportResponse faCatchSummaryReportResponse = responseDto.getData();
-
-        // Total summary table
-        SummaryTable total = faCatchSummaryReportResponse.getTotal();
-        assertTrue(total.getFaCatchTypeSummaries().isEmpty());
-        assertEquals(1, total.getFishSizeSummaries().size());
-
-        SummaryFishSize totalFishSizeSummary = total.getFishSizeSummaries().get(0);
-        assertEquals(FishSizeClassEnum.LSC, totalFishSizeSummary.getFishSize());
-        assertTrue(totalFishSizeSummary.getSpecies().isEmpty());
-        assertEquals(706823.8700000001, totalFishSizeSummary.getFishSizeCount(), 0.01d);
-
-        // Summary records
-        List<FACatchSummaryRecord> summaryRecords = faCatchSummaryReportResponse.getSummaryRecords();
-        assertEquals(2, summaryRecords.size());
-
-        FACatchSummaryRecord faCatchSummaryRecord2013 = summaryRecords.get(0);
-        assertEquals(1, faCatchSummaryRecord2013.getGroups().size());
-        assertEquals(GroupCriteria.DATE_YEAR, faCatchSummaryRecord2013.getGroups().get(0).getKey());
-        assertEquals("2013", faCatchSummaryRecord2013.getGroups().get(0).getValue());
-
-        SummaryTable summaryTable2013 = faCatchSummaryRecord2013.getSummary();
-        assertTrue(summaryTable2013.getFaCatchTypeSummaries().isEmpty());
-
-        List<SummaryFishSize> fishSizeSummaries2013 = summaryTable2013.getFishSizeSummaries();
-        assertEquals(1, fishSizeSummaries2013.size());
-        assertEquals(FishSizeClassEnum.LSC, fishSizeSummaries2013.get(0).getFishSize());
-        assertTrue(fishSizeSummaries2013.get(0).getSpecies().isEmpty());
-        assertEquals(700522.4700000001, fishSizeSummaries2013.get(0).getFishSizeCount(), 0.01d);
-
-        FACatchSummaryRecord faCatchSummaryRecord2012 = summaryRecords.get(1);
-        assertEquals(1, faCatchSummaryRecord2012.getGroups().size());
-        assertEquals(GroupCriteria.DATE_YEAR, faCatchSummaryRecord2012.getGroups().get(0).getKey());
-        assertEquals("2012", faCatchSummaryRecord2012.getGroups().get(0).getValue());
-
-        SummaryTable summaryTable2012 = faCatchSummaryRecord2012.getSummary();
-        assertTrue(summaryTable2012.getFaCatchTypeSummaries().isEmpty());
-
-        List<SummaryFishSize> fishSizeSummaries2012 = summaryTable2012.getFishSizeSummaries();
-        assertEquals(1, fishSizeSummaries2012.size());
-        assertEquals(FishSizeClassEnum.LSC, fishSizeSummaries2012.get(0).getFishSize());
-        assertTrue(fishSizeSummaries2012.get(0).getSpecies().isEmpty());
-        assertEquals(6301.4, fishSizeSummaries2012.get(0).getFishSizeCount(), 0.01d);
-    }
-
-    @Test
-    public void getFACatchSummaryReport_byYearAndTerritory() throws JsonProcessingException {
-        // Given
-        FishingActivityQuery query = new FishingActivityQuery();
-
-        query.setSearchCriteriaMap(new HashMap<>());
-        query.setSearchCriteriaMapMultipleValues(new HashMap<>());
-
-        List<GroupCriteria> groupByFields = new ArrayList<>();
-        groupByFields.add(GroupCriteria.DATE_YEAR);
-        groupByFields.add(GroupCriteria.TERRITORY);
-        query.setGroupByFields(groupByFields);
-
-        // When
-        String responseAsString = getWebTarget()
-                .path("catch")
-                .path("summary")
-                .request(MediaType.APPLICATION_JSON)
-                .header(HttpHeaders.AUTHORIZATION, authToken)
-                .post(Entity.json(query), String.class);
-
-        // Then
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(TypeFactory.defaultInstance()));
-
-        ResponseDto<FACatchSummaryReportResponse> responseDto =
-                objectMapper.readValue(responseAsString, new TypeReference<ResponseDto<FACatchSummaryReportResponse>>(){});
-
-        assertEquals(200, responseDto.getCode());
-        assertNull(responseDto.getMsg());
-
-        FACatchSummaryReportResponse faCatchSummaryReportResponse = responseDto.getData();
-
-        // Total summary table
-        SummaryTable total = faCatchSummaryReportResponse.getTotal();
-        assertTrue(total.getFaCatchTypeSummaries().isEmpty());
-        assertEquals(1, total.getFishSizeSummaries().size());
-
-        SummaryFishSize totalFishSizeSummary = total.getFishSizeSummaries().get(0);
-        assertEquals(FishSizeClassEnum.LSC, totalFishSizeSummary.getFishSize());
-        assertTrue(totalFishSizeSummary.getSpecies().isEmpty());
-        assertEquals(706823.8700000001, totalFishSizeSummary.getFishSizeCount(), 0.01d);
-
-        // Summary records
-        List<FACatchSummaryRecord> summaryRecords = faCatchSummaryReportResponse.getSummaryRecords();
-        assertEquals(3, summaryRecords.size());
-
-        FACatchSummaryRecord faCatchSummaryRecord = summaryRecords.get(2); // Get the last record, that one contains both YEAR and TERRITORY
-
-        List<GroupCriteriaWithValue> groups = faCatchSummaryRecord.getGroups();
-        GroupCriteriaWithValue yearGroup = groups.get(0);
-        GroupCriteriaWithValue territoryGroup = groups.get(1);
-
-        assertEquals("2013", yearGroup.getValue());
-        assertEquals("KEF", territoryGroup.getValue());
-
-        SummaryTable summary = faCatchSummaryRecord.getSummary();
-
-        List<SummaryFishSize> fishSizeSummaries2012 = summary.getFishSizeSummaries();
-        assertEquals(1, fishSizeSummaries2012.size());
-        assertEquals(FishSizeClassEnum.LSC, fishSizeSummaries2012.get(0).getFishSize());
-        assertTrue(fishSizeSummaries2012.get(0).getSpecies().isEmpty());
-        assertEquals(692325.1699999999, fishSizeSummaries2012.get(0).getFishSizeCount(), 0.01d);
     }
 
     /*

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/activity/message/consumer/bean/ActivityMessageConsumerBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/activity/message/consumer/bean/ActivityMessageConsumerBean.java
@@ -20,16 +20,12 @@ import eu.europa.ec.fisheries.uvms.activity.model.mapper.JAXBMarshaller;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.ActivityModuleMethod;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.ActivityModuleRequest;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.ActivityUniquinessList;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.FACatchSummaryReportRequest;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.FACatchSummaryReportResponse;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.FishingTripRequest;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.FishingTripResponse;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.GetNonUniqueIdsRequest;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.GetNonUniqueIdsResponse;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.SetFLUXFAReportOrQueryMessageRequest;
 import eu.europa.ec.fisheries.uvms.activity.service.ActivityRulesModuleService;
-import eu.europa.ec.fisheries.uvms.activity.service.ActivityService;
-import eu.europa.ec.fisheries.uvms.activity.service.FaCatchReportService;
 import eu.europa.ec.fisheries.uvms.activity.service.FishingTripService;
 import eu.europa.ec.fisheries.uvms.activity.service.bean.ActivityMatchingIdsService;
 import eu.europa.ec.fisheries.uvms.activity.service.bean.FluxReportMessageSaver;
@@ -84,13 +80,7 @@ public class ActivityMessageConsumerBean implements MessageListener {
     private ActivityErrorMessageServiceBean producer;
 
     @EJB
-    private FaCatchReportService faCatchReportService;
-
-    @EJB
     private ActivityMatchingIdsService matchingIdsService;
-
-    @EJB
-    private ActivityService activityServiceBean;
 
     @Override
     public void onMessage(Message message) {
@@ -124,12 +114,10 @@ public class ActivityMessageConsumerBean implements MessageListener {
                 case GET_FISHING_TRIPS:
                     getFishingTrips(textMessage);
                     break;
-                case GET_FA_CATCH_SUMMARY_REPORT:
-                    getCatchSummaryReport(textMessage);
-                    break;
                 case GET_NON_UNIQUE_IDS:
                     getNonUniqueIds(textMessage);
                     break;
+                case GET_FA_CATCH_SUMMARY_REPORT:
                 case GET_FISHING_ACTIVITY_FOR_TRIPS:
                 default:
                     log.error("Request method {} is not implemented", method.name());
@@ -151,13 +139,6 @@ public class ActivityMessageConsumerBean implements MessageListener {
         String getNonUniqueIdsResponseString = JAXBMarshaller.marshallJaxBObjectToString(getNonUniqueIdsResponse);
 
         producer.sendResponseMessageToSender(textMessage, getNonUniqueIdsResponseString);
-    }
-
-    private void getCatchSummaryReport(TextMessage textMessage) throws ActivityModelMarshallException, ServiceException, JMSException {
-        FACatchSummaryReportRequest faCatchSummaryReportRequest = JAXBMarshaller.unmarshallTextMessage(textMessage, FACatchSummaryReportRequest.class);
-        FACatchSummaryReportResponse faCatchSummaryReportResponse = faCatchReportService.getFACatchSummaryReportResponse(FishingActivityRequestMapper.buildFishingActivityQueryFromRequest(faCatchSummaryReportRequest));
-        String faCatchSummaryReportResponseString = JAXBMarshaller.marshallJaxBObjectToString(faCatchSummaryReportResponse);
-        producer.sendResponseMessageToSender(textMessage, faCatchSummaryReportResponseString);
     }
 
     private void getFishingTrips(TextMessage textMessage) throws ActivityModelMarshallException, ServiceException, JMSException {

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/activity/service/FaCatchReportService.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/activity/service/FaCatchReportService.java
@@ -10,7 +10,6 @@ details. You should have received a copy of the GNU General Public License along
  */
 package eu.europa.ec.fisheries.uvms.activity.service;
 
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.FACatchSummaryReportResponse;
 import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.FACatchDetailsDTO;
 import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.FACatchSummaryDTO;
 import eu.europa.ec.fisheries.uvms.activity.service.search.FishingActivityQuery;
@@ -18,8 +17,6 @@ import eu.europa.ec.fisheries.uvms.commons.service.exception.ServiceException;
 
 public interface FaCatchReportService {
    FACatchSummaryDTO getCatchSummaryReport(FishingActivityQuery query, boolean isLanding) throws ServiceException;
-
-   FACatchSummaryReportResponse getFACatchSummaryReportResponse(FishingActivityQuery query) throws ServiceException;
 
    FACatchDetailsDTO getCatchDetailsScreen(String tripId) throws ServiceException;
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/activity/service/bean/FaCatchReportServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/activity/service/bean/FaCatchReportServiceBean.java
@@ -13,7 +13,6 @@ package eu.europa.ec.fisheries.uvms.activity.service.bean;
 
 import eu.europa.ec.fisheries.uvms.activity.fa.dao.FaCatchDao;
 import eu.europa.ec.fisheries.uvms.activity.fa.dao.proxy.FaCatchSummaryCustomProxy;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.FACatchSummaryReportResponse;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.GroupCriteria;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.SearchFilter;
 import eu.europa.ec.fisheries.uvms.activity.service.FaCatchReportService;
@@ -24,7 +23,6 @@ import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.Summary
 import eu.europa.ec.fisheries.uvms.activity.service.facatch.FACatchSummaryHelper;
 import eu.europa.ec.fisheries.uvms.activity.service.facatch.FACatchSummaryPresentationHelper;
 import eu.europa.ec.fisheries.uvms.activity.service.facatch.FACatchSummaryReportHelper;
-import eu.europa.ec.fisheries.uvms.activity.service.mapper.FACatchSummaryMapper;
 import eu.europa.ec.fisheries.uvms.activity.service.search.FishingActivityQuery;
 import eu.europa.ec.fisheries.uvms.commons.service.exception.ServiceException;
 import lombok.extern.slf4j.Slf4j;
@@ -96,8 +94,9 @@ public class FaCatchReportServiceBean extends BaseActivityBean implements FaCatc
         groupByFields.add(GroupCriteria.ICES_STAT_RECTANGLE);
         groupByFields.add(GroupCriteria.SPECIES);
 
-        if(isLanding)
-             groupByFields.add(GroupCriteria.PRESENTATION);
+        if (isLanding) {
+            groupByFields.add(GroupCriteria.PRESENTATION);
+        }
 
         return groupByFields;
     }
@@ -129,33 +128,5 @@ public class FaCatchReportServiceBean extends BaseActivityBean implements FaCatc
         faCatchSummaryDTO.setTotal(summaryTableDTOTotal);
 
         return faCatchSummaryDTO;
-    }
-
-    /**
-     * This method is used to create Catch Details page from Run Report.
-     * So, To display summary  of catches, we need to consider all fishing Activity filters as well as aggregation factors specified by user .
-     * Aggregation factors could be dynamically selected by user like veesel,period,area etc.
-     * @param query
-     * @throws ServiceException
-     */
-    @Override
-    public FACatchSummaryReportResponse getFACatchSummaryReportResponse(FishingActivityQuery query) throws ServiceException {
-        log.debug("FACatchSummaryReportResponse creation starts");
-
-        //get processed information in the form of DTO
-        FACatchSummaryDTO faCatchSummaryDTO = getCatchSummaryReport(query,false);
-        log.debug("FACatchSummaryDTO created");
-
-        // We can not transfter DTO as it is over JMS because of JAVA maps.so, Map DTO to the type transferrable over JMS
-        FACatchSummaryHelper faCatchSummaryHelper = new FACatchSummaryReportHelper();
-
-        // Create response object for JMS
-        FACatchSummaryReportResponse faCatchSummaryReportResponse = new FACatchSummaryReportResponse();
-        faCatchSummaryReportResponse.setSummaryRecords(faCatchSummaryHelper.buildFACatchSummaryRecordList(faCatchSummaryDTO.getRecordDTOs()));
-        faCatchSummaryReportResponse.setTotal(FACatchSummaryMapper.INSTANCE.mapToSummaryTable(faCatchSummaryDTO.getTotal()));
-
-        log.debug("SummaryTable XML Schema response---->"+FACatchSummaryHelper.printJsonstructure(faCatchSummaryReportResponse));
-
-        return faCatchSummaryReportResponse;
     }
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/activity/service/facatch/FACatchSummaryHelper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/activity/service/facatch/FACatchSummaryHelper.java
@@ -10,18 +10,13 @@ details. You should have received a copy of the GNU General Public License along
  */
 package eu.europa.ec.fisheries.uvms.activity.service.facatch;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import eu.europa.ec.fisheries.uvms.activity.fa.dao.proxy.FaCatchSummaryCustomChildProxy;
 import eu.europa.ec.fisheries.uvms.activity.fa.dao.proxy.FaCatchSummaryCustomProxy;
+import eu.europa.ec.fisheries.uvms.activity.model.schemas.GroupCriteria;
 import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.FACatchSummaryRecordDTO;
 import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.SummaryTableDTO;
-import eu.europa.ec.fisheries.uvms.activity.service.mapper.FACatchSummaryMapper;
 import eu.europa.ec.fisheries.uvms.activity.service.search.FilterMap;
 import eu.europa.ec.fisheries.uvms.activity.service.search.GroupCriteriaMapper;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.FACatchSummaryRecord;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.GroupCriteria;
 import eu.europa.ec.fisheries.uvms.commons.service.exception.ServiceException;
 import io.jsonwebtoken.lang.Collections;
 import lombok.extern.slf4j.Slf4j;
@@ -54,20 +49,6 @@ public abstract class FACatchSummaryHelper {
     private DateTimeFormatter yearFormatter = DateTimeFormatter.ofPattern("yyyy", Locale.ROOT).withZone(ZoneOffset.UTC.normalized());
     private DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT).withZone(ZoneOffset.UTC.normalized());
     private DateTimeFormatter defaultFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ROOT).withZone(ZoneOffset.UTC.normalized());
-
-    public static String printJsonstructure(Object obj) {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-        String s = null;
-        try {
-            s = mapper.writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
-            log.error("Exception while parsing JSON", e);
-        }
-        log.debug("json structure:-------->");
-        log.debug("" + s);
-        return s;
-    }
 
     /**
      * This method maps raw data fetched from database to customEntity.
@@ -253,18 +234,6 @@ public abstract class FACatchSummaryHelper {
         } else {
             return totalValue + value;
         }
-    }
-
-    public List<FACatchSummaryRecord> buildFACatchSummaryRecordList(List<FACatchSummaryRecordDTO> catchSummaryDTOList) {
-        List<FACatchSummaryRecord> faCatchSummaryRecords = new ArrayList<>();
-        for (FACatchSummaryRecordDTO faCatchSummaryDTO : catchSummaryDTOList) {
-            FACatchSummaryRecord faCatchSummaryRecord = new FACatchSummaryRecord();
-            faCatchSummaryRecord.setGroups(faCatchSummaryDTO.getGroups());
-            faCatchSummaryRecord.setSummary(FACatchSummaryMapper.INSTANCE.mapToSummaryTable(faCatchSummaryDTO.getSummaryTable()));
-            faCatchSummaryRecords.add(faCatchSummaryRecord);
-        }
-        log.debug("List of FACatchSummaryRecord objects created");
-        return faCatchSummaryRecords;
     }
 
     /**

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/activity/service/mapper/FACatchSummaryMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/activity/service/mapper/FACatchSummaryMapper.java
@@ -11,16 +11,12 @@ details. You should have received a copy of the GNU General Public License along
 package eu.europa.ec.fisheries.uvms.activity.service.mapper;
 
 import eu.europa.ec.fisheries.uvms.activity.fa.dao.proxy.FaCatchSummaryCustomProxy;
-import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.FACatchSummaryRecordDTO;
-import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.SummaryTableDTO;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.FaCatchTypeEnum;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.FishSizeClassEnum;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.GroupCriteria;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.GroupCriteriaWithValue;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.SpeciesCount;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.SummaryFACatchtype;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.SummaryFishSize;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.SummaryTable;
+import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.FACatchSummaryRecordDTO;
+import eu.europa.ec.fisheries.uvms.activity.service.dto.fareport.summary.SummaryTableDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
@@ -55,14 +51,6 @@ public abstract class FACatchSummaryMapper extends BaseMapper {
     })
     public abstract FACatchSummaryRecordDTO mapToFACatchSummaryRecordDTOWithPresentation(FaCatchSummaryCustomProxy customEntity, List<FaCatchSummaryCustomProxy> catchSummaryEntityList);
 
-
-    @Mappings({
-            @Mapping(target = "fishSizeSummaries", expression = "java(getSummaryFishSizeList(summaryTableDTO.getSummaryFishSize()))"),
-            @Mapping(target = "faCatchTypeSummaries", expression = "java(getFaCatchTypeSummaries(summaryTableDTO.getSummaryFaCatchType()))")
-    })
-    public abstract SummaryTable mapToSummaryTable(SummaryTableDTO summaryTableDTO);
-
-
     /**
      * Create List of Group Criterias. Add only those groups which have some value associated with them.
      *
@@ -71,76 +59,72 @@ public abstract class FACatchSummaryMapper extends BaseMapper {
     public List<GroupCriteriaWithValue> populateGroupCriteriaWithValue(FaCatchSummaryCustomProxy customEntity) {
         List<GroupCriteriaWithValue> groups = new ArrayList<>();
 
-        if(customEntity ==null){
+        if (customEntity ==null) {
             return groups;
         }
 
-        if(StringUtils.isNotEmpty(customEntity.getDate() ) ){
+        if (StringUtils.isNotEmpty(customEntity.getDate())) {
             groups.add( new GroupCriteriaWithValue(GroupCriteria.DATE,customEntity.getDate()));
         }
 
-        if(StringUtils.isNotEmpty(customEntity.getDay() ) ){
+        if (StringUtils.isNotEmpty(customEntity.getDay())) {
             groups.add( new GroupCriteriaWithValue(GroupCriteria.DATE_DAY,customEntity.getDay()));
         }
 
-        if(StringUtils.isNotEmpty(customEntity.getMonth())){
+        if (StringUtils.isNotEmpty(customEntity.getMonth())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.DATE_MONTH,customEntity.getMonth()));
         }
 
-
-        if(StringUtils.isNotEmpty(customEntity.getYear())){
+        if (StringUtils.isNotEmpty(customEntity.getYear())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.DATE_YEAR,customEntity.getYear()));
         }
 
-        if(StringUtils.isNotEmpty(customEntity.getEffortZone())){
+        if (StringUtils.isNotEmpty(customEntity.getEffortZone())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.EFFORT_ZONE,customEntity.getEffortZone()));
         }
 
-        if(StringUtils.isNotEmpty(customEntity.getFaoArea())){
+        if (StringUtils.isNotEmpty(customEntity.getFaoArea())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.FAO_AREA,customEntity.getFaoArea()));
         }
 
-        if(StringUtils.isNotEmpty(customEntity.getGfcmGsa())){
+        if (StringUtils.isNotEmpty(customEntity.getGfcmGsa())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.GFCM_GSA,customEntity.getGfcmGsa()));
         }
 
-        if(StringUtils.isNotEmpty(customEntity.getGfcmStatRectangle())){
+        if (StringUtils.isNotEmpty(customEntity.getGfcmStatRectangle())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.GFCM_STAT_RECTANGLE,customEntity.getGfcmStatRectangle()));
         }
 
-        if(StringUtils.isNotEmpty(customEntity.getIcesStatRectangle())){
+        if (StringUtils.isNotEmpty(customEntity.getIcesStatRectangle())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.ICES_STAT_RECTANGLE,customEntity.getIcesStatRectangle()));
         }
-        if(StringUtils.isNotEmpty(customEntity.getTerritory())){
+
+        if (StringUtils.isNotEmpty(customEntity.getTerritory())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.TERRITORY,customEntity.getTerritory()));
         }
 
-        if(StringUtils.isNotEmpty(customEntity.getRfmo())){
-
+        if (StringUtils.isNotEmpty(customEntity.getRfmo())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.RFMO,customEntity.getRfmo()));
         }
 
-        if(StringUtils.isNotEmpty(customEntity.getFlagState())){
+        if (StringUtils.isNotEmpty(customEntity.getFlagState())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.FLAG_STATE,customEntity.getFlagState()));
         }
 
-        if(StringUtils.isNotEmpty(customEntity.getGearType())){
+        if (StringUtils.isNotEmpty(customEntity.getGearType())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.GEAR_TYPE,customEntity.getGearType()));
         }
 
-
-        if(StringUtils.isNotEmpty(customEntity.getPresentation())){
+        if (StringUtils.isNotEmpty(customEntity.getPresentation())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.PRESENTATION,customEntity.getPresentation()));
         }
 
-        if(StringUtils.isNotEmpty(customEntity.getVesselTransportGuid())){
+        if (StringUtils.isNotEmpty(customEntity.getVesselTransportGuid())) {
             groups.add(new GroupCriteriaWithValue(GroupCriteria.VESSEL,customEntity.getVesselTransportGuid()));
         }
 
         return groups;
-
     }
-
 
     /**
      * Process All rows belonging to same group to calculate weights. And create Summary table structure
@@ -364,71 +348,6 @@ public abstract class FACatchSummaryMapper extends BaseMapper {
         }
         return faCatchSummaryMap;
     }
-
-  protected List<SummaryFishSize> getSummaryFishSizeList(Map<FishSizeClassEnum,Object> summaryFishSizeMap){
-        if(MapUtils.isEmpty(summaryFishSizeMap)){
-            return new ArrayList<>();
-        }
-
-        List<SummaryFishSize> summaryFishSizes = new ArrayList<>();
-
-        for (Map.Entry<FishSizeClassEnum, Object> entry : summaryFishSizeMap.entrySet()) {
-                SummaryFishSize summaryFishSize = new SummaryFishSize();
-                summaryFishSize.setFishSize(entry.getKey());
-
-                Object value = entry.getValue();
-                if(value instanceof Map) {
-                     summaryFishSize.setSpecies(getSpeciesCounts((Map<String, Double>) value));
-                }else if(value instanceof  Double){
-                    summaryFishSize.setFishSizeCount((Double) value);
-                }
-                summaryFishSizes.add(summaryFishSize);
-            }
-
-        log.debug("SummaryFishSize List is created");
-        return summaryFishSizes;
-
-    }
-
-
-
-   protected List<SummaryFACatchtype> getFaCatchTypeSummaries(Map<FaCatchTypeEnum,Object> summaryFaCatchTypeMap){
-        List<SummaryFACatchtype> summaryFishCatchTypes = new ArrayList<>();
-
-        if(!MapUtils.isEmpty(summaryFaCatchTypeMap)) {
-
-            for (Map.Entry<FaCatchTypeEnum, Object> entry : summaryFaCatchTypeMap.entrySet()) {
-                SummaryFACatchtype summaryFACatchtype = new SummaryFACatchtype();
-                summaryFACatchtype.setCatchType(entry.getKey());
-
-                Object value = entry.getValue();
-                if(value instanceof Map) {
-                    summaryFACatchtype.setSpecies(getSpeciesCounts((Map<String, Double>) value));
-                }else if(value instanceof  Double){
-                    summaryFACatchtype.setCatchTypeCount((Double) value);
-                }
-                summaryFishCatchTypes.add(summaryFACatchtype);
-            }
-        }
-       log.debug("SummaryFACatchtype List is created");
-        return summaryFishCatchTypes;
-    }
-
-    @NotNull
-    private List<SpeciesCount> getSpeciesCounts(Map<String, Double> speciesMap) {
-        if(MapUtils.isEmpty(speciesMap)){
-            return new ArrayList<>();
-        }
-        List<SpeciesCount> speciesCounts = new ArrayList<>();
-        for (Map.Entry<String, Double> entrySpecies : speciesMap.entrySet()) {
-            SpeciesCount speciesCount = new SpeciesCount();
-            speciesCount.setSpaciesName(entrySpecies.getKey());
-            speciesCount.setCount(entrySpecies.getValue());
-            speciesCounts.add(speciesCount);
-        }
-        return speciesCounts;
-    }
-
 
     private void populateSpeciesMap(FaCatchSummaryCustomProxy customEntity, Double speciesCnt, Map<String, Double> speciesCountMap) {
         Double totalCountForSpecies = speciesCountMap.get(customEntity.getSpecies().toUpperCase());


### PR DESCRIPTION
We decided to remove this method because it's confusing and difficult to use and we don't see a use for it right now. Also, removing it clears up more code.