### PR TITLE
[UNIONVMS-4303] Distinguish FaReportDocumentEntity objects based on the report IDs

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/ers/fa/entities/FaReportDocumentEntity.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/fa/entities/FaReportDocumentEntity.java
@@ -14,6 +14,7 @@ package eu.europa.ec.fisheries.ers.fa.entities;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 import java.util.Set;
 import com.vividsolutions.jts.geom.Geometry;
 import lombok.Data;
@@ -66,7 +67,6 @@ import org.hibernate.annotations.Type;
 @Table(name = "activity_fa_report_document")
 @Data
 @ToString(of = "id")
-@EqualsAndHashCode(of = {"acceptedDatetime"})
 @NoArgsConstructor
 public class FaReportDocumentEntity implements Serializable {
 
@@ -129,4 +129,17 @@ public class FaReportDocumentEntity implements Serializable {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "faReportDocument", cascade = CascadeType.ALL)
     private Set<VesselTransportMeansEntity> vesselTransportMeans;
 
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof FaReportDocumentEntity
+                && (
+                    (this.fluxReportDocument == null && ((FaReportDocumentEntity) other).fluxReportDocument == null)
+                    || (this.fluxReportDocument != null && ((FaReportDocumentEntity) other).fluxReportDocument != null && Objects.equals(this.fluxReportDocument.getFluxReportIdentifiers(), ((FaReportDocumentEntity) other).fluxReportDocument.getFluxReportIdentifiers()))
+                );
+    }
+
+    @Override
+    public int hashCode() {
+        return fluxReportDocument == null || fluxReportDocument.getFluxReportIdentifiers() == null ? 0 : fluxReportDocument.getFluxReportIdentifiers().stream().mapToInt(Object::hashCode).sum();
+    }
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/bean/ActivityMatchingIdsServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/bean/ActivityMatchingIdsServiceBean.java
@@ -25,7 +25,6 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.persistence.EntityManager;
-import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +34,6 @@ import java.util.List;
  */
 @Stateless
 @LocalBean
-@Transactional
 @Slf4j
 public class ActivityMatchingIdsServiceBean extends BaseActivityBean {
 


### PR DESCRIPTION
Custom `hashCode()` and `equals()`, see discussion in [issue](https://webgate.ec.europa.eu/CITnet/jira/browse/UNIONVMS-4303).

Until now report entities (`FaReportDocumentEntity`) would have their `hashCode()` and `equals()` implemented based on the `acceptedDatetime`. This is obviously wrong, as it causes the system to lose reports within a message having the same `acceptedDatetime`.