### PR TITLE
[UNIONVMS-4203] Added @Transactional back to ActivityMatchingIdsServiceBean

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/bean/ActivityMatchingIdsServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/bean/ActivityMatchingIdsServiceBean.java
@@ -25,6 +25,7 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -34,6 +35,7 @@ import java.util.List;
  */
 @Stateless
 @LocalBean
+@Transactional
 @Slf4j
 public class ActivityMatchingIdsServiceBean extends BaseActivityBean {
 


### PR DESCRIPTION
It seems to need it, but it doesn't make sense. To be investigated further.