### PR TITLE
[UNIONVMS-4711] FaQueryFactory ignores empty vessel identifiers.

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/base/FaQueryFactory.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/ers/service/mapper/view/base/FaQueryFactory.java
@@ -114,6 +114,7 @@ public class FaQueryFactory {
 
     private static Optional<FAQueryParameter> chooseVesselIdentifier(List<VesselIdentifierType> vesselIdentifiers) {
         return vesselIdentifiers.stream()
+                .filter(vesselIdentifier -> !vesselIdentifier.getValue().isEmpty())
                 .max(Comparator.comparing(VesselIdentifierType::getKey, Comparator.comparing(VESSELID_PRIORITIES::get, Comparator.nullsFirst(Comparator.naturalOrder()))))
                 .map(id -> new FAQueryParameter(createCodeType(VESSELID, FA_QUERY_PARAMETER), null, null, createIDType(id.getValue(), id.getKey().name())));
     }

--- a/service/src/test/java/eu/europa/ec/fisheries/ers/service/mapper/FaQueryFactoryTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/ers/service/mapper/FaQueryFactoryTest.java
@@ -134,8 +134,37 @@ public class FaQueryFactoryTest {
         Assert.assertFalse(query.getSimpleFAQueryParameters().stream().anyMatch(p -> p.getTypeCode().getValue().equals(FaQueryFactory.VESSELID)));
         Assert.assertEquals(1, query.getSimpleFAQueryParameters().size());
     }
+    
+    @Test
+    public void testVesselIdentifierPriorityEmptyCfr() throws DatatypeConfigurationException {
+        List<VesselIdentifierType> identifiers = new ArrayList<>();
+        identifiers.add(new VesselIdentifierType(VesselIdentifierSchemeIdEnum.GFCM, "GFCM"));
+        identifiers.add(new VesselIdentifierType(VesselIdentifierSchemeIdEnum.CFR, ""));
+        identifiers.add(new VesselIdentifierType(VesselIdentifierSchemeIdEnum.IRCS, "IRCS12"));
+        identifiers.add(new VesselIdentifierType(VesselIdentifierSchemeIdEnum.UVI, "UVI1212"));
+        identifiers.add(new VesselIdentifierType(VesselIdentifierSchemeIdEnum.EXT_MARK, "EXT_MARK1212"));
+        identifiers.add(new VesselIdentifierType(VesselIdentifierSchemeIdEnum.ICCAT, "ICCAT12"));
+        FAQuery query = FaQueryFactory.createFaQueryWithVesselId("submitter", identifiers, true,
+                DatatypeFactory.newInstance().newXMLGregorianCalendar("2019-01-01T10:00:00"), DatatypeFactory.newInstance().newXMLGregorianCalendar("2019-02-01T10:00:00"));
+        Assert.assertEquals("IRCS12", query.getSimpleFAQueryParameters().get(0).getValueID().getValue());
+        Assert.assertEquals("IRCS", query.getSimpleFAQueryParameters().get(0).getValueID().getSchemeID());
+        Assert.assertEquals(2, query.getSimpleFAQueryParameters().size());
+    }
 
-
-
-
+    @Test
+    public void testVesselIdentifierPriorityEmptyCfrAndEmptyIRCS() throws DatatypeConfigurationException {
+        List<VesselIdentifierType> identifiers = new ArrayList<>();
+        identifiers.add(new VesselIdentifierType(VesselIdentifierSchemeIdEnum.GFCM, "GFCM"));
+        identifiers.add(new VesselIdentifierType(VesselIdentifierSchemeIdEnum.CFR, ""));
+        identifiers.add(new VesselIdentifierType(VesselIdentifierSchemeIdEnum.IRCS, ""));
+        identifiers.add(new VesselIdentifierType(VesselIdentifierSchemeIdEnum.UVI, "UVI1212"));
+        identifiers.add(new VesselIdentifierType(VesselIdentifierSchemeIdEnum.EXT_MARK, "EXT_MARK1212"));
+        identifiers.add(new VesselIdentifierType(VesselIdentifierSchemeIdEnum.ICCAT, "ICCAT12"));
+        FAQuery query = FaQueryFactory.createFaQueryWithVesselId("submitter", identifiers, true,
+                DatatypeFactory.newInstance().newXMLGregorianCalendar("2019-01-01T10:00:00"), DatatypeFactory.newInstance().newXMLGregorianCalendar("2019-02-01T10:00:00"));
+        Assert.assertEquals("UVI1212", query.getSimpleFAQueryParameters().get(0).getValueID().getValue());
+        Assert.assertEquals("UVI", query.getSimpleFAQueryParameters().get(0).getValueID().getSchemeID());
+        Assert.assertEquals(2, query.getSimpleFAQueryParameters().size());
+    }
+    
 }


### PR DESCRIPTION
https://citnet.tech.ec.europa.eu/CITnet/jira/browse/UNIONVMS-4711